### PR TITLE
Add updateOnChange flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,11 @@
                     "type": "string",
                     "description": "Path to the standard library."
                 },
+                "effekt.updateOnChange": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Process file on every change, even when not saved. When disabled, autocomplete may not work reliably."
+                },
                 "effekt.debug": {
                     "type": "boolean",
                     "default": false,


### PR DESCRIPTION
Kiama's `updateOnChange` setting was never implemented or used anywhere. Is there a reason for this?

I suggest enabling the setting by default so requests like `textDocument/completion` or `textDocument/hover` don't have to `process()` the file first seperately.
