### PR TITLE
Improve syntax highlighting

### DIFF
--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -9,6 +9,7 @@
     { "include": "#keywords" },
     { "include": "#names" },
     { "include": "#strings" },
+    { "include": "#characters" },
     { "include": "#numbers" },
     { "include": "#holes" }
   ],
@@ -159,7 +160,10 @@
     },
     "characters": {
       "patterns": [{
-        "match": "'(\\\\.|[^'\\\\])'",
+        "match": "'(\\\\[nrt\\\\']|[^'\\\\])'",
+        "name": "string.quoted.single.char.effekt"
+      }, {
+        "match": "\\\\u[0-9A-Fa-f]{4}",
         "name": "string.quoted.single.char.effekt"
       }]
     },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Effekt",
+  "foldingStartMarker": "(?<![\"'])(/\\*\\*|\\{\\s*$)",
+  "foldingStopMarker": "(?<![\"'])(\\*\\*/|^\\s*\\})",
   "patterns": [
     { "include": "#comments" },
     { "include": "#definitions" },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -105,10 +105,10 @@
     "keywords": {
       "patterns": [{
         "match": "\\b(module|import|def|fun|val|var|effect|type|match|case|record|extern|include|box|unbox|in|region|new|resource|interface|namespace|module|include|export|as)\\b",
-        "name": "keyword.syntax"
+        "name": "keyword.syntax.effekt"
       }, {
         "match": "\\b(resume|while|try|with|if|else|do|return|is|and)\\b",
-        "name": "keyword.control"
+        "name": "keyword.control.effekt"
       }]
     },
     "literals": {
@@ -163,14 +163,14 @@
       "patterns": [{
         "match": "\\b([a-z][a-zA-Z0-9_]*)\\b[\\s]*[({\\[]",
         "captures": {
-          "1": { "name": "entity.name.function" }
+          "1": { "name": "entity.name.function.effekt" }
         }
       }, {
         "match": "\\b[a-z][a-zA-Z0-9_]*\\b",
-        "name": "variable"
+        "name": "variable.effekt"
       }, {
         "match": "\\b[A-Z][a-zA-Z0-9_]*\\b",
-        "name": "entity.name.type"
+        "name": "entity.name.type.effekt"
       }]
     },
     "stringTemplates": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -102,11 +102,20 @@
     },
     "keywords": {
       "patterns": [{
-        "match": "\\b(module|import|def|fun|val|var|effect|type|match|case|record|extern|include|box|unbox|in|region|new|resource|interface|namespace|module|include|export|as)\\b",
+        "match": "\\b(module|import|def|fun|val|var|effect|type|record|extern|include|box|unbox|in|region|new|resource|interface|namespace|module|include|export|as)\\b",
         "name": "keyword.syntax.effekt"
       }, {
-        "match": "\\b(resume|while|try|with|if|else|do|return|is|and)\\b",
-        "name": "keyword.control.effekt"
+        "match": "\\b(resume|return)\\b",
+        "name": "keyword.control.flow.jump.effekt"
+      }, {
+        "match": "\\b(do|try|with)\\b",
+        "name": "keyword.control.flow.effects.effekt"
+      }, {
+        "match": "\\b(while|match|case|if|else)\\b",
+        "name": "keyword.control.flow.effekt"
+      }, {
+        "match": "\\b(is|and)\\b",
+        "name": "keyword.operator.effekt"
       }]
     },
     "literals": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -9,7 +9,8 @@
     { "include": "#keywords" },
     { "include": "#names" },
     { "include": "#literals" },
-    { "include": "#holes" }
+    { "include": "#holes" },
+    { "include": "#operators" }
   ],
   "repository": {
     "comments": {
@@ -198,6 +199,27 @@
       "name": "meta.hole.effekt",
       "patterns": [{
         "include": "$self"
+      }]
+    },
+    "operators": {
+      "patterns": [{
+        "match": "\\|\\||&&",
+        "name": "keyword.operator.logical.effekt"
+      }, {
+        "match": "==|!=|<=|>=|<|>",
+        "name": "keyword.operator.comparison.effekt"
+      }, {
+        "match": "\\+\\+",
+        "name": "keyword.operator.concatenation.effekt"
+      }, {
+        "match": "\\+\\+|\\+|-|\\*|/",
+        "name": "keyword.operator.arithmetic.effekt"
+      }, {
+        "match": "::",
+        "name": "keyword.operator.namespace.effekt"
+      }, {
+        "match": "=>",
+        "name": "keyword.operator.arrow.effekt"
       }]
     }
   },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -123,9 +123,9 @@
     },
     "strings": {
       "patterns": [{
-        "begin": "\"",
-        "end": "\"",
-        "name": "string.quoted.double.literal",
+        "begin": "\"\"\"",
+        "end": "\"\"\"",
+        "name": "string.quoted.triple.literal",
         "patterns": [{
           "include": "#stringTemplates"
         }, {
@@ -133,9 +133,9 @@
           "name": "constant.character.escape.effekt"
         }]
       }, {
-        "begin": "\"\"\"",
-        "end": "\"\"\"",
-        "name": "string.quoted.triple.literal",
+        "begin": "\"",
+        "end": "\"",
+        "name": "string.quoted.double.literal",
         "patterns": [{
           "include": "#stringTemplates"
         }, {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -14,13 +14,29 @@
     "comments": {
       "patterns": [
         {
-          "match": "//.*$\n?",
-          "name": "comment.line.double-slash.syntax"
+          "begin": "//",
+          "end": "\\n",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.effekt"
+            }
+          },
+          "name": "comment.line.double-slash.effekt"
         },
 				{
-					"begin": "\\s*+(\\/\\*)",
-					"end": "\\*\\/",
-					"name": "comment.multiline.syntax"
+					"begin": "/\\*",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.effekt"
+            }
+          },
+          "end": "\\*/",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.comment.effekt"
+            }
+          },
+          "name": "comment.block.effekt"
 				}
       ]
     },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -70,7 +70,7 @@
           "patterns": [{
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {
-              "1": { "name": "keyword.syntax.in.effekt" },
+              "1": { "name": "keyword.other.in.effekt" },
               "2": { "name": "entity.name.region.effekt" }
             }
           }, {
@@ -98,7 +98,7 @@
         }, {
           "match": "\\s*(import)\\s+((?:[a-zA-Z][a-zA-Z0-9_]*(?:/[a-zA-Z][a-zA-Z0-9_]*)*))\\b",
           "captures": {
-            "1": { "name": "keyword.syntax.import.effekt" },
+            "1": { "name": "keyword.other.import.effekt" },
             "2": { "name": "entity.name.module.import.effekt" }
           }
         }]
@@ -142,7 +142,7 @@
     "keywords": {
       "patterns": [{
         "match": "\\b(module|import|def|fun|val|var|effect|type|record|include|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
-        "name": "keyword.syntax.effekt"
+        "name": "keyword.other.effekt"
       }, {
         "match": "\\b(resume|return)\\b",
         "name": "keyword.control.jump.effekt"
@@ -284,7 +284,7 @@
       "patterns": [{
         "match": "\\b(region)\\s+([a-zA-Z][a-zA-Z0-9_]*)\\b",
         "captures": {
-          "1": { "name": "keyword.syntax.region.effekt" },
+          "1": { "name": "keyword.other.region.effekt" },
           "2": { "name": "entity.name.region.effekt" }
         }
       }]

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -18,17 +18,13 @@
         "begin": "//",
         "end": "\\n",
         "beginCaptures": {
-          "0": {
-            "name": "punctuation.definition.comment.effekt"
-          }
+          "0": { "name": "punctuation.definition.comment.effekt" }
         },
         "name": "comment.line.double-slash.effekt"
       }, {
         "begin": "/\\*",
         "beginCaptures": {
-          "0": {
-            "name": "punctuation.definition.comment.effekt"
-          }
+          "0": { "name": "punctuation.definition.comment.effekt" }
         },
         "end": "\\*/",
         "endCaptures": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -168,10 +168,16 @@
       }]
     },
     "numbers": {
-      "patterns": [{
-        "match": "\\b[0-9]+",
-        "name": "constant.numeric"
-      }]
+      "patterns": [
+        {
+          "match": "\\b([0-9]+\\.[0-9]+)\\b",
+          "name": "constant.numeric.float.effekt"
+        },
+        {
+          "match": "\\b([0-9]+)\\b",
+          "name": "constant.numeric.integer.effekt"
+        }
+      ]
     },
     "punctuation": {
       "patterns": [{

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -12,33 +12,30 @@
   ],
   "repository": {
     "comments": {
-      "patterns": [
-        {
-          "begin": "//",
-          "end": "\\n",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.effekt"
-            }
-          },
-          "name": "comment.line.double-slash.effekt"
+      "patterns": [{
+        "begin": "//",
+        "end": "\\n",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.comment.effekt"
+          }
         },
-				{
-					"begin": "/\\*",
-          "beginCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.effekt"
-            }
-          },
-          "end": "\\*/",
-          "endCaptures": {
-            "0": {
-              "name": "punctuation.definition.comment.effekt"
-            }
-          },
-          "name": "comment.block.effekt"
-				}
-      ]
+        "name": "comment.line.double-slash.effekt"
+      }, {
+        "begin": "/\\*",
+        "beginCaptures": {
+          "0": {
+            "name": "punctuation.definition.comment.effekt"
+          }
+        },
+        "end": "\\*/",
+        "endCaptures": {
+          "0": {
+            "name": "punctuation.definition.comment.effekt"
+          }
+        },
+        "name": "comment.block.effekt"
+      }]
     },
     "definitions": {
       "patterns": [{
@@ -108,32 +105,27 @@
       }]
     },
     "strings": {
-      "patterns": [
-        {
-          "begin": "\"",
-          "end": "\"",
-          "name": "string.quoted.double.literal",
-          "patterns": [
-            { "include": "#stringTemplates" },
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escape.effekt"
-            }
-          ]
-        },
-        {
-          "begin": "\"\"\"",
-          "end": "\"\"\"",
-          "name": "string.quoted.triple.literal",
-          "patterns": [
-            { "include": "#stringTemplates" },
-            {
-              "match": "\\\\.",
-              "name": "constant.character.escape.effekt"
-            }
-          ]
-        }
-      ]
+      "patterns": [{
+        "begin": "\"",
+        "end": "\"",
+        "name": "string.quoted.double.literal",
+        "patterns": [{
+          "include": "#stringTemplates"
+        }, {
+          "match": "\\\\.",
+          "name": "constant.character.escape.effekt"
+        }]
+      }, {
+        "begin": "\"\"\"",
+        "end": "\"\"\"",
+        "name": "string.quoted.triple.literal",
+        "patterns": [{
+          "include": "#stringTemplates"
+        }, {
+          "match": "\\\\.",
+          "name": "constant.character.escape.effekt"
+        }]
+      }]
     },
     "stringTemplates": {
       "begin": "\\$\\{",
@@ -150,12 +142,10 @@
       ]
     },
     "characters": {
-      "patterns": [
-        {
-          "match": "'(\\\\.|[^'\\\\])'",
-          "name": "string.quoted.single.char.effekt"
-        }
-      ]
+      "patterns": [{
+        "match": "'(\\\\.|[^'\\\\])'",
+        "name": "string.quoted.single.char.effekt"
+      }]
     },
     "numbers": {
       "patterns": [{

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -165,8 +165,9 @@
       "begin": "'",
       "end": "'",
       "patterns": [{
-        "name": "constant.character.escape.effekt",
-        "match": "\\\\((u[0-9a-fA-F]{4})|.)"
+        "include": "#escapes"
+      }, {
+        "include": "#invalidEscapes"
       }]
     },
     "strings": {
@@ -174,10 +175,8 @@
         "name": "string.quoted.triple.effekt",
         "begin": "\"\"\"",
         "end": "\"\"\"",
+        "comment": "Important: only single-line strings can have escapes!",
         "patterns": [{
-          "name": "constant.character.escape.effekt",
-          "match": "\\\\((u[0-9a-fA-F]{4})|.)"
-        }, {
           "include": "#stringTemplates"
         }]
       }, {
@@ -185,12 +184,22 @@
         "begin": "\"",
         "end": "\"",
         "patterns": [{
-          "name": "constant.character.escape.effekt",
-          "match": "\\\\((u[0-9a-fA-F]{4})|.)"
+          "include": "#escapes"
+        }, {
+          "include": "#invalidEscapes"
         }, {
           "include": "#stringTemplates"
         }]
       }]
+    },
+    "escapes": {
+      "match": "\\\\([btnfr\\\\\"']|u[0-9A-Fa-f]{4})",
+      "name": "constant.character.escape.effekt"
+    },
+    "invalidEscapes": {
+      "match": "\\\\.",
+      "name": "invalid.illegal.unknown-escape.effekt",
+      "comment": "Represents any possible escape, therefore should always be used _after_ #escapes!"
     },
     "names": {
       "patterns": [{

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -71,7 +71,16 @@
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {
               "1": { "name": "keyword.other.in.effekt" },
-              "2": { "name": "variable.other.capability.effekt entity.name.region.effekt" }            }
+              "2": {
+                "patterns": [{
+                  "match": "global",
+                  "name": "support.constant.effekt variable.other.capability.effekt entity.name.region.effekt"
+                }, {
+                  "match": "[a-zA-Z][a-z-A-Z0-9_$]*",
+                  "name": "variable.other.capability.effekt entity.name.region.effekt"
+                }]
+              }
+            }
           }, {
             "include": "#parameters"
           }]
@@ -131,8 +140,11 @@
         "match": "\\b(pure)\\b",
         "name": "keyword.other.capability.pure.effekt"
       }, {
-        "match": "\\b(io|global)\\b",
+        "match": "\\b(io)\\b",
         "name": "support.constant.effekt variable.other.capability.effekt"
+      }, {
+        "match": "\\b(global)\\b",
+        "name": "support.constant.effekt variable.other.capability.effekt entity.name.region.effekt"
       }, {
         "match": "\\b([a-z][a-zA-Z0-9_]*)\\b",
         "name": "variable.other.capability.effekt"

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -36,7 +36,7 @@
     "definitions": {
       "patterns": [{
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?=\\=|\\n)",
+          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
           "captures": {
             "1": { "name": "keyword.declaration.type" },
             "2": { "patterns": [{ "include": "#capabilities" }] },
@@ -46,7 +46,7 @@
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?=\\=|\\n)",
+          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
           "captures": {
             "1": { "name": "keyword.declaration.function" },
             "2": { "name": "entity.name.function" }
@@ -64,7 +64,7 @@
             "1": { "name": "keyword.declaration.var" },
             "2": { "name": "variable" }
           },
-          "end": "(?=\\=|\\n)",
+          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
           "patterns": [{
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -155,7 +155,7 @@
     },
     "keywords": {
       "patterns": [{
-        "match": "\\b(module|import|def|fun|val|var|effect|type|record|include|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
+        "match": "\\b(module|import|def|fun|val|var|effect|type|record|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
         "name": "keyword.other.effekt"
       }, {
         "match": "\\b(resume|return)\\b",

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -38,13 +38,21 @@
     },
     "definitions": {
       "patterns": [{
-          "begin": "\\s*(extern)?\\s*(\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end" : "[=\\n]",
-          "beginCaptures": {
-            "1": { "name": "keyword.declaration.type" },
-            "2": { "patterns": [{ "include": "#capabilities" }] },
-            "3": { "name": "keyword.declaration.function" },
-            "4": { "name": "entity.name.function" }
+          "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "end": "[=\\n]",
+          "captures": {
+              "1": { "name": "keyword.declaration.type" },
+              "2": { "patterns": [{ "include": "#capabilities" }] },
+              "3": { "name": "keyword.declaration.function.extern" },
+              "4": { "name": "entity.name.function" }
+            },
+          "patterns": [{ "include": "#parameters" }]
+        }, {
+          "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "end": "[=\\n]",
+          "captures": {
+            "1": { "name": "keyword.declaration.function" },
+            "2": { "name": "entity.name.function" }
           },
           "patterns": [{ "include": "#parameters" }]
         }, {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -71,8 +71,7 @@
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {
               "1": { "name": "keyword.other.in.effekt" },
-              "2": { "name": "entity.name.region.effekt" }
-            }
+              "2": { "name": "variable.other.capability.effekt entity.name.region.effekt" }            }
           }, {
             "include": "#parameters"
           }]
@@ -131,6 +130,9 @@
       "patterns": [{
         "match": "\\b(pure)\\b",
         "name": "keyword.other.capability.pure.effekt"
+      }, {
+        "match": "\\b(io|global)\\b",
+        "name": "support.constant.effekt variable.other.capability.effekt"
       }, {
         "match": "\\b([a-z][a-zA-Z0-9_]*)\\b",
         "name": "variable.other.capability.effekt"
@@ -285,7 +287,7 @@
         "match": "\\b(region)\\s+([a-zA-Z][a-zA-Z0-9_]*)\\b",
         "captures": {
           "1": { "name": "keyword.other.region.effekt" },
-          "2": { "name": "entity.name.region.effekt" }
+          "2": { "name": "variable.other.capability.effekt entity.name.region.effekt" }
         }
       }]
     }

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -155,20 +155,17 @@
     },
     "keywords": {
       "patterns": [{
-        "match": "\\b(module|import|def|fun|val|var|effect|type|record|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
+        "match": "\\b(module|import|def|fun|val|var|effect|type|record|box|unbox|region|new|resource|interface|namespace|module|include|export)\\b",
         "name": "keyword.other.effekt"
       }, {
-        "match": "\\b(resume|return)\\b",
+        "match": "\\b(return)\\b",
         "name": "keyword.control.jump.effekt"
       }, {
-        "match": "\\b(do|try|with)\\b",
+        "match": "\\b(do|resume|try|with)\\b",
         "name": "keyword.control.effect.effekt"
       }, {
-        "match": "\\b(while|match|case|if|else)\\b",
+        "match": "\\b(while|match|case|if|else|is|and)\\b",
         "name": "keyword.control.flow.effekt"
-      }, {
-        "match": "\\b(is|and)\\b",
-        "name": "keyword.operator.effekt"
       }, {
         "match": "\\b(extern)\\b",
         "name": "storage.modifier.extern.effekt"

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -6,6 +6,7 @@
   "patterns": [
     { "include": "#comments" },
     { "include": "#definitions" },
+    { "include": "#regions" },
     { "include": "#keywords" },
     { "include": "#boxed_types" },
     { "include": "#literals" },
@@ -271,6 +272,15 @@
       }, {
         "match": "=>",
         "name": "keyword.operator.arrow.effekt"
+      }]
+    },
+    "regions": {
+      "patterns": [{
+        "match": "\\b(region)\\s+([a-zA-Z][a-zA-Z0-9_]*)\\b",
+        "captures": {
+          "1": { "name": "keyword.syntax.region.effekt" },
+          "2": { "name": "entity.name.region.effekt" }
+        }
       }]
     }
   },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -8,9 +8,7 @@
     { "include": "#definitions" },
     { "include": "#keywords" },
     { "include": "#names" },
-    { "include": "#strings" },
-    { "include": "#characters" },
-    { "include": "#numbers" },
+    { "include": "#literals" },
     { "include": "#holes" }
   ],
   "repository": {
@@ -112,11 +110,56 @@
         "name": "keyword.control"
       }]
     },
-    "names": {
+    "literals": {
       "patterns": [{
         "match": "\\b(true|false)\\b",
-        "name": "constant.language"
+        "name": "constant.language.boolean.effekt"
       }, {
+        "match": "\\b([0-9]+\\.[0-9]+)\\b",
+        "name": "constant.numeric.float.effekt"
+      }, {
+        "match": "\\b([0-9]+)\\b",
+        "name": "constant.numeric.integer.effekt"
+      }, {
+        "include": "#characters"
+      }, {
+        "include": "#strings"
+      }]
+    },
+    "characters": {
+      "name": "string.quoted.single.effekt",
+      "begin": "'",
+      "end": "'",
+      "patterns": [{
+        "name": "constant.character.escape.effekt",
+        "match": "\\\\((u[0-9a-fA-F]{4})|.)"
+      }]
+    },
+    "strings": {
+      "patterns": [{
+        "name": "string.quoted.triple.effekt",
+        "begin": "\"\"\"",
+        "end": "\"\"\"",
+        "patterns": [{
+          "name": "constant.character.escape.effekt",
+          "match": "\\\\((u[0-9a-fA-F]{4})|.)"
+        }, {
+          "include": "#stringTemplates"
+        }]
+      }, {
+        "name": "string.quoted.double.effekt",
+        "begin": "\"",
+        "end": "\"",
+        "patterns": [{
+          "name": "constant.character.escape.effekt",
+          "match": "\\\\((u[0-9a-fA-F]{4})|.)"
+        }, {
+          "include": "#stringTemplates"
+        }]
+      }]
+    },
+    "names": {
+      "patterns": [{
         "match": "\\b([a-z][a-zA-Z0-9_]*)\\b[\\s]*[({\\[]",
         "captures": {
           "1": { "name": "entity.name.function" }
@@ -127,29 +170,6 @@
       }, {
         "match": "\\b[A-Z][a-zA-Z0-9_]*\\b",
         "name": "entity.name.type"
-      }]
-    },
-    "strings": {
-      "patterns": [{
-        "begin": "\"\"\"",
-        "end": "\"\"\"",
-        "name": "string.quoted.triple.literal",
-        "patterns": [{
-          "include": "#stringTemplates"
-        }, {
-          "match": "\\\\.",
-          "name": "constant.character.escape.effekt"
-        }]
-      }, {
-        "begin": "\"",
-        "end": "\"",
-        "name": "string.quoted.double.literal",
-        "patterns": [{
-          "include": "#stringTemplates"
-        }, {
-          "match": "\\\\.",
-          "name": "constant.character.escape.effekt"
-        }]
       }]
     },
     "stringTemplates": {
@@ -164,27 +184,6 @@
       "name": "meta.embedded.line.effekt",
       "patterns": [
         { "include": "$self" }
-      ]
-    },
-    "characters": {
-      "patterns": [{
-        "match": "'(\\\\[nrt\\\\']|[^'\\\\])'",
-        "name": "string.quoted.single.char.effekt"
-      }, {
-        "match": "\\\\u[0-9A-Fa-f]{4}",
-        "name": "string.quoted.single.char.effekt"
-      }]
-    },
-    "numbers": {
-      "patterns": [
-        {
-          "match": "\\b([0-9]+\\.[0-9]+)\\b",
-          "name": "constant.numeric.float.effekt"
-        },
-        {
-          "match": "\\b([0-9]+)\\b",
-          "name": "constant.numeric.integer.effekt"
-        }
       ]
     },
     "punctuation": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -194,13 +194,11 @@
       }]
     },
     "holes": {
+      "begin": "<{",
+      "end": "}>",
+      "name": "meta.hole.effekt",
       "patterns": [{
-        "begin": "<{",
-        "end" : "}>",
-        "name": "effekt.hole",
-        "patterns": [{
-          "include": "source.effekt"
-        }]
+        "include": "$self"
       }]
     }
   },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -39,31 +39,31 @@
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
           "captures": {
-            "1": { "name": "keyword.declaration.type" },
+            "1": { "name": "storage.modifier.extern.effekt" },
             "2": { "patterns": [{ "include": "#capabilities" }] },
-            "3": { "name": "keyword.declaration.function.extern" },
-            "4": { "name": "entity.name.function" }
+            "3": { "name": "keyword.declaration.function.extern.effekt" },
+            "4": { "name": "entity.name.function.effekt" }
           },
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
           "captures": {
-            "1": { "name": "keyword.declaration.function" },
-            "2": { "name": "entity.name.function" }
+            "1": { "name": "keyword.declaration.function.effekt" },
+            "2": { "name": "entity.name.function.effekt" }
           },
           "patterns": [{ "include": "#parameters" }]
         }, {
           "match": "\\s*(val)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "captures": {
-            "1": { "name": "keyword.declaration.val" },
-            "2": { "name": "variable" }
+            "1": { "name": "keyword.declaration.val.effekt" },
+            "2": { "name": "variable.other.effekt" }
           }
         }, {
           "begin": "\\s*(var)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "beginCaptures": {
-            "1": { "name": "keyword.declaration.var" },
-            "2": { "name": "variable" }
+            "1": { "name": "keyword.declaration.var.effekt" },
+            "2": { "name": "variable.other.effekt" }
           },
           "end": "(?:;|(?=\\n)|(?<=\\S)\\s*(?==(?!>)))",
           "patterns": [{
@@ -78,15 +78,21 @@
         }, {
           "match": "\\s*(extern)?\\s*(type|effect|interface|resource)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "captures": {
-            "1": { "name": "keyword.declaration.type" },
-            "2": { "name": "keyword.declaration.type" },
-            "3": { "name": "entity.name.type" }
+            "1": { "name": "storage.modifier.extern.effekt" },
+            "2": { "name": "keyword.declaration.type.effekt" },
+            "3": { "name": "entity.name.type.effekt" }
           }
         }, {
           "match": "\\s*(namespace)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "captures": {
-            "1": { "name": "keyword.declaration.namespace" },
-            "2": { "name": "entity.name.namespace" }
+            "1": { "name": "keyword.declaration.namespace.effekt" },
+            "2": { "name": "entity.name.namespace.effekt" }
+          }
+        }, {
+          "match": "\\s*(module)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "captures": {
+            "1": { "name": "keyword.declaration.module.effekt" },
+            "2": { "name": "entity.name.module.effekt" }
           }
         }]
     },
@@ -95,7 +101,7 @@
       "patterns": [{
         "begin": "\\b(at)\\s*\\{",
         "beginCaptures": {
-          "1": { "name": "keyword.syntax.at.effekt" }
+          "1": { "name": "keyword.other.at.effekt" }
         },
         "end": "\\}",
         "patterns": [{
@@ -108,40 +114,43 @@
         "include": "#boxed_types"
       }, {
         "match": "\\b([a-z][a-zA-Z0-9_$]*)(?:)",
-        "name": "variable.parameter"
+        "name": "variable.parameter.effekt"
       }, {
         "match": "\\b([A-Z][a-zA-Z0-9_$]*)(?:)",
-        "name": "entity.name.type"
+        "name": "entity.name.type.effekt"
       }]
     },
     "capabilities": {
       "patterns": [{
         "match": "\\b(pure)\\b",
-        "name": "keyword.other.capability"
+        "name": "keyword.other.capability.pure.effekt"
       }, {
         "match": "\\b([a-z][a-zA-Z0-9_]*)\\b",
-        "name": "variable.other.capability"
+        "name": "variable.other.capability.effekt"
       }, {
         "match": ",",
-        "name": "punctuation.capability-set.comma"
+        "name": "punctuation.separator.capability.effekt"
       }]
     },
     "keywords": {
       "patterns": [{
-        "match": "\\b(module|import|def|fun|val|var|effect|type|record|extern|include|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
+        "match": "\\b(module|import|def|fun|val|var|effect|type|record|include|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
         "name": "keyword.syntax.effekt"
       }, {
         "match": "\\b(resume|return)\\b",
-        "name": "keyword.control.flow.jump.effekt"
+        "name": "keyword.control.jump.effekt"
       }, {
         "match": "\\b(do|try|with)\\b",
-        "name": "keyword.control.flow.effects.effekt"
+        "name": "keyword.control.effect.effekt"
       }, {
         "match": "\\b(while|match|case|if|else)\\b",
         "name": "keyword.control.flow.effekt"
       }, {
         "match": "\\b(is|and)\\b",
         "name": "keyword.operator.effekt"
+      }, {
+        "match": "\\b(extern)\\b",
+        "name": "storage.modifier.extern.effekt"
       }]
     },
     "literals": {
@@ -209,7 +218,7 @@
         }
       }, {
         "match": "\\b[a-z][a-zA-Z0-9_]*\\b",
-        "name": "variable.effekt"
+        "name": "variable.other.effekt"
       }, {
         "match": "\\b[A-Z][a-zA-Z0-9_]*\\b",
         "name": "entity.name.type.effekt"
@@ -232,7 +241,7 @@
     "punctuation": {
       "patterns": [{
         "match": "[{}\\(\\)\\[\\];,]",
-        "name": "punctuation.separator"
+        "name": "punctuation.separator.effekt"
       }]
     },
     "holes": {
@@ -254,7 +263,7 @@
         "match": "\\+\\+",
         "name": "keyword.operator.concatenation.effekt"
       }, {
-        "match": "\\+\\+|\\+|-|\\*|/",
+        "match": "\\+|-|\\*|/",
         "name": "keyword.operator.arithmetic.effekt"
       }, {
         "match": "::",

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -36,7 +36,7 @@
     "definitions": {
       "patterns": [{
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "[=\\n]",
+          "end": "(?=\\=|\\n)",
           "captures": {
             "1": { "name": "keyword.declaration.type" },
             "2": { "patterns": [{ "include": "#capabilities" }] },
@@ -46,7 +46,7 @@
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "[=\\n]",
+          "end": "(?=\\=|\\n)",
           "captures": {
             "1": { "name": "keyword.declaration.function" },
             "2": { "name": "entity.name.function" }
@@ -64,7 +64,7 @@
             "1": { "name": "keyword.declaration.var" },
             "2": { "name": "variable" }
           },
-          "end": "[=\\n]",
+          "end": "(?=\\=|\\n)",
           "patterns": [{
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -43,7 +43,7 @@
           "end" : "[=\\n]",
           "beginCaptures": {
             "1": { "name": "keyword.declaration.type" },
-            "2": { "name": "entity.name.type" },
+            "2": { "name": "variable.other.capability.effekt" },
             "3": { "name": "keyword.declaration.function" },
             "4": { "name": "entity.name.function" }
           },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -28,9 +28,7 @@
         },
         "end": "\\*/",
         "endCaptures": {
-          "0": {
-            "name": "punctuation.definition.comment.effekt"
-          }
+          "0": { "name": "punctuation.definition.comment.effekt" }
         },
         "name": "comment.block.effekt"
       }]
@@ -40,11 +38,11 @@
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "end": "[=\\n]",
           "captures": {
-              "1": { "name": "keyword.declaration.type" },
-              "2": { "patterns": [{ "include": "#capabilities" }] },
-              "3": { "name": "keyword.declaration.function.extern" },
-              "4": { "name": "entity.name.function" }
-            },
+            "1": { "name": "keyword.declaration.type" },
+            "2": { "patterns": [{ "include": "#capabilities" }] },
+            "3": { "name": "keyword.declaration.function.extern" },
+            "4": { "name": "entity.name.function" }
+          },
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -108,11 +108,54 @@
       }]
     },
     "strings": {
-      "patterns": [{
-        "begin": "\"",
-        "end": "\"",
-        "name": "string.quoted.double.literal"
-      }]
+      "patterns": [
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.literal",
+          "patterns": [
+            { "include": "#stringTemplates" },
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.effekt"
+            }
+          ]
+        },
+        {
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "name": "string.quoted.triple.literal",
+          "patterns": [
+            { "include": "#stringTemplates" },
+            {
+              "match": "\\\\.",
+              "name": "constant.character.escape.effekt"
+            }
+          ]
+        }
+      ]
+    },
+    "stringTemplates": {
+      "begin": "\\$\\{",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.template-expression.begin.effekt" }
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.template-expression.end.effekt" }
+      },
+      "name": "meta.embedded.line.effekt",
+      "patterns": [
+        { "include": "$self" }
+      ]
+    },
+    "characters": {
+      "patterns": [
+        {
+          "match": "'(\\\\.|[^'\\\\])'",
+          "name": "string.quoted.single.char.effekt"
+        }
+      ]
     },
     "numbers": {
       "patterns": [{

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -72,6 +72,8 @@
               "1": { "name": "keyword.syntax.in.effekt" },
               "2": { "name": "entity.name.region.effekt" }
             }
+          }, {
+            "include": "#parameters"
           }]
         }, {
           "match": "\\s*(extern)?\\s*(type|effect|interface|resource)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -67,6 +67,12 @@
             "2": { "name": "keyword.declaration.type" },
             "3": { "name": "entity.name.type" }
           }
+        }, {
+          "match": "\\s*(namespace)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "captures": {
+            "1": { "name": "keyword.declaration.namespace" },
+            "2": { "name": "entity.name.namespace" }
+          }
         }]
     },
     "parameters": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -37,7 +37,7 @@
     "definitions": {
       "patterns": [{
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
+          "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
           "captures": {
             "1": { "name": "keyword.declaration.type" },
             "2": { "patterns": [{ "include": "#capabilities" }] },
@@ -47,7 +47,7 @@
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
+          "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
           "captures": {
             "1": { "name": "keyword.declaration.function" },
             "2": { "name": "entity.name.function" }
@@ -65,7 +65,7 @@
             "1": { "name": "keyword.declaration.var" },
             "2": { "name": "variable" }
           },
-          "end": "(?:(?=\\n)|(?=\\b(?:(?!=>)[^=]>\\b)|(?:(?!>)\\=)))",
+          "end": "(?:;|(?=\\n)|(?<=\\S)\\s*(?==(?!>)))",
           "patterns": [{
             "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
             "captures": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -8,8 +8,8 @@
     { "include": "#definitions" },
     { "include": "#keywords" },
     { "include": "#boxed_types" },
-    { "include": "#names" },
     { "include": "#literals" },
+    { "include": "#names" },
     { "include": "#holes" },
     { "include": "#operators" }
   ],

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -7,6 +7,7 @@
     { "include": "#comments" },
     { "include": "#definitions" },
     { "include": "#keywords" },
+    { "include": "#boxed_types" },
     { "include": "#names" },
     { "include": "#literals" },
     { "include": "#holes" },
@@ -87,8 +88,23 @@
           }
         }]
     },
+    "boxed_types": {
+      "comment": "Used for boxed types like 'at {}', 'at {io}', 'at {io, global}', etc.",
+      "patterns": [{
+        "begin": "\\b(at)\\s*\\{",
+        "beginCaptures": {
+          "1": { "name": "keyword.syntax.at.effekt" }
+        },
+        "end": "\\}",
+        "patterns": [{
+          "include": "#capabilities"
+        }]
+      }]
+    },
     "parameters": {
       "patterns": [{
+        "include": "#boxed_types"
+      }, {
         "match": "\\b([a-z][a-zA-Z0-9_$]*)(?:)",
         "name": "variable.parameter"
       }, {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -90,10 +90,16 @@
             "2": { "name": "entity.name.namespace.effekt" }
           }
         }, {
-          "match": "\\s*(module)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "match": "\\s*(module)\\s+((?:[a-zA-Z][a-zA-Z0-9_]*(?:/[a-zA-Z][a-zA-Z0-9_]*)*))\\b",
           "captures": {
             "1": { "name": "keyword.declaration.module.effekt" },
             "2": { "name": "entity.name.module.effekt" }
+          }
+        }, {
+          "match": "\\s*(import)\\s+((?:[a-zA-Z][a-zA-Z0-9_]*(?:/[a-zA-Z][a-zA-Z0-9_]*)*))\\b",
+          "captures": {
+            "1": { "name": "keyword.syntax.import.effekt" },
+            "2": { "name": "entity.name.module.import.effekt" }
           }
         }]
     },

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -43,7 +43,7 @@
           "end" : "[=\\n]",
           "beginCaptures": {
             "1": { "name": "keyword.declaration.type" },
-            "2": { "name": "variable.other.capability.effekt" },
+            "2": { "patterns": [{ "include": "#capabilities" }] },
             "3": { "name": "keyword.declaration.function" },
             "4": { "name": "entity.name.function" }
           },
@@ -82,6 +82,18 @@
       }, {
         "match": "\\b([A-Z][a-zA-Z0-9_$]*)(?:)",
         "name": "entity.name.type"
+      }]
+    },
+    "capabilities": {
+      "patterns": [{
+        "match": "\\b(pure)\\b",
+        "name": "keyword.other.capability"
+      }, {
+        "match": "\\b([a-z][a-zA-Z0-9_]*)\\b",
+        "name": "variable.other.capability"
+      }, {
+        "match": ",",
+        "name": "punctuation.capability-set.comma"
       }]
     },
     "keywords": {

--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -59,11 +59,19 @@
             "2": { "name": "variable" }
           }
         }, {
-          "match": "\\s*(var)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "captures": {
+          "begin": "\\s*(var)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+          "beginCaptures": {
             "1": { "name": "keyword.declaration.var" },
             "2": { "name": "variable" }
-          }
+          },
+          "end": "[=\\n]",
+          "patterns": [{
+            "match": "\\s+(in)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
+            "captures": {
+              "1": { "name": "keyword.syntax.in.effekt" },
+              "2": { "name": "entity.name.region.effekt" }
+            }
+          }]
         }, {
           "match": "\\s*(extern)?\\s*(type|effect|interface|resource)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
           "captures": {
@@ -102,7 +110,7 @@
     },
     "keywords": {
       "patterns": [{
-        "match": "\\b(module|import|def|fun|val|var|effect|type|record|extern|include|box|unbox|in|region|new|resource|interface|namespace|module|include|export|as)\\b",
+        "match": "\\b(module|import|def|fun|val|var|effect|type|record|extern|include|box|unbox|region|new|resource|interface|namespace|module|include|export|as)\\b",
         "name": "keyword.syntax.effekt"
       }, {
         "match": "\\b(resume|return)\\b",


### PR DESCRIPTION
### Changes
- parse comments precisely
- support splices in (currently all) strings
- support individual characters
- support escapes in strings and characters
- support multi-line strings
- support namespace declarations
- parse capability sets precisely
- add folding markers
- support float literals
- parse typed holes in line with the rest of the file
- add operator support (only visible in some themes)
- `in` is now a conditional keyword (rendered as a keyword only in `var x in r = ...`)
- fix definitions being stuck at `=>` and then not parsing the rest of the arguments
- highlight `at` correctly
- highlight invalid escapes
- highlight `module`s and `import`s correctly
- add support for `region`

### Caveats / open questions
- currently, we only highlight `'\uA0EB'` char literals as opposed to `\uA0EB` detected in the parser, see issue https://github.com/effekt-lang/effekt/issues/521

### Future work
- precise parsing of extern defs
- add support for identifiers that use `?` and `!` (I tried, but I couldn't get it to work)
- add a test suite (low-prio, but it would be nice to know we're somewhat stable)
- use semantic highlighting from the compiler via LSP: https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide, then we could even distinguish an effect type from a normal type, a parameter from a variable, etc. :)
  - demo gifs here: https://github.com/Microsoft/vscode-languageserver-node/pull/367#issuecomment-411043236
- support `box {<capabilities>*} { ... }` syntax

### Screenshots (before [left] vs after [right])

<img width="1058" alt="Screenshot 2024-07-20 at 09 19 13" src="https://github.com/user-attachments/assets/eefeea0e-19e1-4062-b1a6-04f4f488d32a">
<img width="998" alt="Screenshot 2024-07-20 at 09 19 46" src="https://github.com/user-attachments/assets/6e878e73-10b8-45a2-bcdd-3c66dfe2c042">
<img width="1099" alt="Screenshot 2024-07-20 at 09 21 59" src="https://github.com/user-attachments/assets/51838ce2-266d-455d-bc64-1af7f4bf61f4">
<img width="1005" alt="Screenshot 2024-07-20 at 09 23 46" src="https://github.com/user-attachments/assets/ee03d18a-be4f-4fea-ac0c-a32d44f1d7f5">
<img width="1225" alt="Screenshot 2024-07-20 at 10 52 03" src="https://github.com/user-attachments/assets/0e540688-1be3-4742-950e-fa5792dfe20c">
<img width="1321" alt="Screenshot 2024-07-20 at 14 42 40" src="https://github.com/user-attachments/assets/4b323231-fa7c-4ca1-97fc-9bc717aaea37">
<img width="945" alt="Screenshot 2024-07-20 at 18 15 22" src="https://github.com/user-attachments/assets/5e3a753c-e438-4a30-af2e-d653fa2bf114">
<img width="1370" alt="Screenshot 2024-07-21 at 18 14 46" src="https://github.com/user-attachments/assets/8896570d-15c0-4b70-a7f8-da1ae7110671">
<img width="1279" alt="Screenshot 2024-07-22 at 10 46 27" src="https://github.com/user-attachments/assets/0c33e235-d6ff-48bf-a5c0-df34e0697810">