### PR TITLE
CI: Deploy to the VSCode marketplace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,9 +75,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Set up NodeJS ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -93,4 +90,9 @@ jobs:
           path: ./
 
       - name: Publish to VSCode Marketplace
-        run: vsce publish -p ${{ secrets.VSCE_PAT }}
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          # -i: Specifies the path to the .vsix file to publish
+          # $(ls *.vsix): Finds the .vsix file in the current directory
+          vsce publish -i $(ls *.vsix)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 env:
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '18.x'
 
 jobs:
   build-vscode:
@@ -14,18 +14,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - name: Set up NodeJS ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ env.NODE_VERSION }}
+  
     - run: npm install -g typescript
     - run: npm install -g vsce
     - run: npm install
+
     - name: Package VSCode extension into .vsix file
       run: vsce package --out effekt.vsix
 
     - name: Upload vsix file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: effekt-vscode
         path: effekt.vsix
@@ -36,17 +39,17 @@ jobs:
     needs: [build-vscode]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download VSCode artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: effekt-vscode
           path: distribution/
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -84,7 +87,7 @@ jobs:
         run: npm install -g vsce
 
       - name: Download VSCode artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: effekt-vscode
           path: ./

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,23 @@
-# This is a copy-and-past version of ci.yml but additionally creating a release
-name: Release Artifacts
+name: Release Artifacts and Deploy
 
 on:
   push:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+env:
+  NODE_VERSION: '12.x'
+
 jobs:
   build-vscode:
     name: Build the VSCode extension
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Node.js
-      uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - name: Set up NodeJS ${{ env.NODE_VERSION }}
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
+        node-version: ${{ env.NODE_VERSION }}
     - run: npm install -g typescript
     - run: npm install -g vsce
     - run: npm install
@@ -22,7 +25,7 @@ jobs:
       run: vsce package --out effekt.vsix
 
     - name: Upload vsix file
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: effekt-vscode
         path: effekt.vsix
@@ -33,10 +36,10 @@ jobs:
     needs: [build-vscode]
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Download VSCode artifact
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: effekt-vscode
           path: distribution/
@@ -47,11 +50,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          release_name: Prerelease ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           tag_name: ${{ github.ref }}
           body: Automatic release for ${{ github.ref }}
           draft: false
-          prerelease: true
+          prerelease: false
 
       - name: Upload vsix file
         id: upload_vsix
@@ -63,3 +66,28 @@ jobs:
           asset_path: ./distribution/effekt.vsix
           asset_name: effekt-vscode-extension.vsix
           asset_content_type: application/zip
+
+  deploy:
+    name: Deploy to VSCode Marketplace
+    runs-on: ubuntu-latest
+    needs: [release]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up NodeJS ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install vsce
+        run: npm install -g vsce
+
+      - name: Download VSCode artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: effekt-vscode
+          path: ./
+
+      - name: Publish to VSCode Marketplace
+        run: vsce publish -p ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Resolves #21

**Untested**, needs `VSCE_PAT` (a personal access token for publishing an extension, see [here](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token))