### PR TITLE
Reformat package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,40 +21,57 @@
     ],
     "main": "./out/extension",
     "contributes": {
-        "languages": [{
-            "id": "effekt",
-            "extensions": [
-                ".effekt"
-            ],
-            "aliases": [
-                "Effekt",
-                "effekt"
-            ],
-            "configuration": "./language-configuration.json"
-        }, {
-            "id": "literate effekt",
-            "extensions": [".effekt.md"],
-            "aliases": ["literate effekt"],
-            "configuration": "./language-configuration.json"
-        }, {
-            "id": "ir",
-            "extensions": [".ir"],
-            "aliases": ["ir", "IR"],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "effekt",
-            "scopeName": "source.effekt",
-            "path": "./syntaxes/effekt.tmLanguage.json"
-        },{
-            "language": "literate effekt",
-            "scopeName": "source.literateeffekt",
-            "path": "./syntaxes/literateeffekt.tmLanguage.json"
-        },{
-            "language": "ir",
-            "scopeName": "source.ir",
-            "path": "./syntaxes/ir.tmLanguage.json"
-        }],
+        "languages": [
+            {
+                "id": "effekt",
+                "extensions": [
+                    ".effekt"
+                ],
+                "aliases": [
+                    "Effekt",
+                    "effekt"
+                ],
+                "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "literate effekt",
+                "extensions": [
+                    ".effekt.md"
+                ],
+                "aliases": [
+                    "literate effekt"
+                ],
+                "configuration": "./language-configuration.json"
+            },
+            {
+                "id": "ir",
+                "extensions": [
+                    ".ir"
+                ],
+                "aliases": [
+                    "ir",
+                    "IR"
+                ],
+                "configuration": "./language-configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "effekt",
+                "scopeName": "source.effekt",
+                "path": "./syntaxes/effekt.tmLanguage.json"
+            },
+            {
+                "language": "literate effekt",
+                "scopeName": "source.literateeffekt",
+                "path": "./syntaxes/literateeffekt.tmLanguage.json"
+            },
+            {
+                "language": "ir",
+                "scopeName": "source.ir",
+                "path": "./syntaxes/ir.tmLanguage.json"
+            }
+        ],
         "configuration": {
             "type": "object",
             "title": "Effekt",
@@ -66,7 +83,14 @@
                 "effekt.backend": {
                     "type": "string",
                     "default": "js",
-                    "enum": ["js", "llvm", "chez-monadic", "chez-callcc", "chez-lift", "ml"],
+                    "enum": [
+                        "js",
+                        "llvm",
+                        "chez-monadic",
+                        "chez-callcc",
+                        "chez-lift",
+                        "ml"
+                    ],
                     "enumDescriptions": [
                         "Use the JavaScript backend.",
                         "Use the LLVM backend.",
@@ -89,7 +113,14 @@
                 "effekt.showIR": {
                     "type": "string",
                     "default": "none",
-                    "enum": ["none", "source", "core", "lifted-core", "machine", "target"],
+                    "enum": [
+                        "none",
+                        "source",
+                        "core",
+                        "lifted-core",
+                        "machine",
+                        "target"
+                    ],
                     "enumDescriptions": [
                         "Disable showing intermediate representation.",
                         "Show source tree after parsing.",


### PR DESCRIPTION
### Motivation

`npm version major/minor/patch` can change the version of the currently developed `npm` package:
- by bumping major/minor/patch in `package.json`
- making a commit
- and a `git tag`

... which makes it very nice to use to make a deploy using a single command.

Unfortunately, it reformats the `package.json` file into a more standard version. It's still 4 spaces, but a bit more verbose.
I think the trade-off is worth it here, just to make releasing a bit easier.

### Description

I ran `npm version patch` and only selectively added the things that do _not_ change the version, thus making the diff smaller for an actual release.