### PR TITLE
Continue single-line comments after pressing enter

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -11,7 +11,7 @@
     "autoClosingPairs": [
         ["{", "}"],
         ["[", "]"],
-        ["(", ")"],
+        ["(", ")"]
     ],
     "surroundingPairs": [
         ["{", "}"],
@@ -20,7 +20,23 @@
         ["<{", "}>"]
     ],
     "folding": {
-        "offSide": false,
+        "offSide": false
     },
-    "wordPattern": "([a-zA-Z][a-zA-Z0-9_]*)"
+    "wordPattern": "([a-zA-Z][a-zA-Z0-9_]*)",
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*//[^/].*$",
+            "action": {
+                "appendText": "// ",
+				"indent": "none"
+            }
+        },
+        {
+            "beforeText": "^\\s*///.*$",
+            "action": {
+                "appendText": "/// ",
+				"indent": "none"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
Closes issue #19 by continuing `//` and `///` single-line comments automagically.

Except that it's not configurable. That's due to our choice of using a static `language-configuration.json`.