### PR TITLE
Code lens for running `main`

### DIFF
--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -508,7 +508,7 @@ export class EffektManager {
      * Gets the command arguments for starting the Effekt server.
      * @returns An array of command arguments.
      */
-    public getEffektArgs(): string[] {
+    public getEffektArgs(server: boolean = true): string[] {
         const args: string[] = [];
         const effektBackend = this.config.get<string>("backend");
         const effektLib = this.config.get<string>("lib");
@@ -519,7 +519,9 @@ export class EffektManager {
         const folders = vscode.workspace.workspaceFolders || [];
         folders.forEach(folder => args.push("--includes", folder.uri.fsPath));
 
-        args.push("--server");
+        if (server) {
+            args.push("--server");
+        }
         return args;
     }
 }

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -505,10 +505,10 @@ export class EffektManager {
     }
 
     /**
-     * Gets the command arguments for starting the Effekt server.
+     * Gets the command arguments for starting Effekt.
      * @returns An array of command arguments.
      */
-    public getEffektArgs(server: boolean = true): string[] {
+    public getEffektArgs(): string[] {
         const args: string[] = [];
         const effektBackend = this.config.get<string>("backend");
         const effektLib = this.config.get<string>("lib");
@@ -519,9 +519,6 @@ export class EffektManager {
         const folders = vscode.workspace.workspaceFolders || [];
         folders.forEach(folder => args.push("--includes", folder.uri.fsPath));
 
-        if (server) {
-            args.push("--server");
-        }
         return args;
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,6 +107,10 @@ export async function activate(context: vscode.ExtensionContext) {
         vscode.languages.registerCodeLensProvider(
             { language: 'effekt', scheme: 'file' },
             new EffektRunCodeLensProvider()
+        ),
+        vscode.languages.registerCodeLensProvider(
+            { language: 'literate effekt', scheme: 'file' },
+            new EffektRunCodeLensProvider()
         )
     );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ async function getEffektRepl() {
         effektRepl = vscode.window.createTerminal({
             name: 'Effekt REPL',
             shellPath: effektExecutable.path,
-            shellArgs: effektManager.getEffektArgs(/* server = */ false),
+            shellArgs: effektManager.getEffektArgs(),
             isTransient: true, // Don't persist across VSCode restarts
         });
         effektRepl.show();
@@ -131,7 +131,7 @@ export async function activate(context: vscode.ExtensionContext) {
         };
     } else {
         const effektExecutable = await effektManager.locateEffektExecutable();
-        const args = effektManager.getEffektArgs();
+        const args = ["--server", ...effektManager.getEffektArgs()];
 
         /* > Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set.
          * > If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors.


### PR DESCRIPTION
Addresses the `main` (haha!) part of #12 by adding "Run" options over `def main()`, that opens up a REPL, imports a file, and runs it:
<img width="512" alt="Screenshot 2024-10-20 at 17 53 56" src="https://github.com/user-attachments/assets/b68d276e-b891-4432-8480-a9f290330772">

---

How does it work?
- search for functions that look like `def main() =`
- if it finds one, create a code lens for the URI/file it is in
- clicking run creates a REPL terminal (if it doesn't exist for that file already), imports the file and runs `main`

The code still needs heavy refactoring and a bit of testing, this is just a proof of concept born out of frustration.

---

**TODO:**
- [x] literate effekt
- [x] should the "Run" button also save the file? otherwise the results might be unexpected (otherwise it runs on the previous saved version)
- [x] ~~how do other languages manage the terminals? should there always be only at most one for the whole project?~~ ~> one per project only
- [x] ~~should the terminal be even a terminal? wouldn't it be better if it was just an output?~~ ~> REPL terminal
- [ ] use a custom, less talkative, path-taking `:import`? (see below)
- [ ] ideally, get a list of "runnable" defs from the compiler (no args, no effects, no custom captures), then show this `|> Run` button over all of those instead of showing it only over things starting with `def main()` [as outlined in #12]