### PR TITLE
[WIP] Use inlay hints to render captures

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ class EffektCapturesProvider implements vscode.InlayHintsProvider {
                     const hint = new vscode.InlayHint(position, response.captureText, vscode.InlayHintKind.Type);
 
                     // This tooltip is useful when there are a lot of captures.
-                    hint.tooltip = new vscode.MarkdownString(`Captures: ${response.captureText}`);
+                    hint.tooltip = new vscode.MarkdownString(`Captures: \`${response.captureText}\``);
                     hint.paddingRight = true;
                     hint.paddingLeft = false;
                     inlayHintCache[document.uri.toString()].push(hint);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,7 +117,12 @@ class EffektCapturesProvider implements vscode.InlayHintsProvider {
                 if (response.location.uri.toString() === document.uri.toString()) {
                     log("... URI correct => creating a hint!")
                     const position = response.location.range.start;
-                    const hint = new vscode.InlayHint(position, response.captureText, vscode.InlayHintKind.Type);
+
+                    // Truncate long captures ourselves.
+                    // TODO: Does this make sense? Shouldn't we at least show the first one?
+                    // TODO: Can the backend send them in a list so that we can have a somewhat stable (alphabetic?) order?
+                    const hintText = response.captureText.length > 24 ? "{…}" : response.captureText;
+                    const hint = new vscode.InlayHint(position, hintText, vscode.InlayHintKind.Type);
 
                     // This tooltip is useful when there are a lot of captures.
                     hint.tooltip = new vscode.MarkdownString(`Captures: \`${response.captureText}\``);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,7 +121,7 @@ class EffektCapturesProvider implements vscode.InlayHintsProvider {
                     // Truncate long captures ourselves.
                     // TODO: Does this make sense? Shouldn't we at least show the first one?
                     // TODO: Can the backend send them in a list so that we can have a somewhat stable (alphabetic?) order?
-                    const hintText = response.captureText.length > 24 ? "{…}" : response.captureText;
+                    const hintText = response.captureText.length > 30 ? "{…}" : response.captureText;
                     const hint = new vscode.InlayHint(position, hintText, vscode.InlayHintKind.Type);
 
                     // This tooltip is useful when there are a lot of captures.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,10 +83,9 @@ class EffektRunCodeLensProvider implements vscode.CodeLensProvider {
     }
 }
 
-let outputChannel = vscode.window.createOutputChannel("Effekt DEBUG");
-
+let debugOutputChannel = vscode.window.createOutputChannel("Effekt DEBUG");
 function log(message: string) {
-    outputChannel.appendLine(message);
+    debugOutputChannel.appendLine(message);
 }
 class EffektCapturesProvider implements vscode.InlayHintsProvider {
     public async provideInlayHints(document: vscode.TextDocument, range: vscode.Range): Promise<vscode.InlayHint[]> {
@@ -110,9 +109,10 @@ class EffektCapturesProvider implements vscode.InlayHintsProvider {
             for (const response of result) {
                 log("processing a single response: " + JSON.stringify(response))
                 if (response.location.uri.toString() === document.uri.toString()) {
-                    log("... URI correct!")
+                    log("... URI correct => creating a hint!")
                     const position = response.location.range.start;
                     const hint = new vscode.InlayHint(position, response.captureText, vscode.InlayHintKind.Type);
+                    hint.tooltip = undefined; // NOTE: We could add a tooltip here if we wanted one.
                     hint.paddingRight = true;
                     hint.paddingLeft = false;
                     hints.push(hint);
@@ -258,48 +258,7 @@ export async function activate(context: vscode.ExtensionContext) {
         timeout = setTimeout(updateHoles, 50);
     }
 
-    /*function updateCaptures() {
-        if (!editor) { return; }
-
-        if (!config.get<boolean>("showCaptures")) { return; }
-
-        client.sendRequest(ExecuteCommandRequest.type, { command: "inferredCaptures", arguments: [{
-            uri: editor.document.uri.toString()
-        }]}).then(
-            (result : [{ location: vscode.Location, captureText: string }]) => {
-                if (!editor) { return; }
-
-                let captureAnnotations: vscode.DecorationOptions[] = [];
-
-                if (result == null) return;
-
-                result.forEach(response => {
-                    if (!editor) { return; }
-                    const loc = response.location;
-                    if (loc.uri != editor.document.uri) return;
-
-                    captureAnnotations.push({
-                        range: loc.range,
-                        renderOptions: {
-                            before: {
-                                contentText: response.captureText,
-                                backgroundColor: "rgba(170,210,255,0.3)",
-                                color: "rgba(50,50,50,0.5)",
-                                fontStyle: "italic",
-                                margin: "0 0.5em 0 0.5em"
-                            }
-                        }
-                    });
-                });
-
-                if (!editor) { return; }
-                return editor.setDecorations(captureDecoration, captureAnnotations);
-            }
-        );
-    }*/
-
-    const holeRegex = /<>|<{|}>/g;
-
+    const holeRegex = /<>|<{|}>/g
     /**
      * TODO clean this up -- ideally move it to the language server
      */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,9 @@ class EffektCapturesProvider implements vscode.InlayHintsProvider {
                     log("... URI correct => creating a hint!")
                     const position = response.location.range.start;
                     const hint = new vscode.InlayHint(position, response.captureText, vscode.InlayHintKind.Type);
-                    hint.tooltip = undefined; // NOTE: We could add a tooltip here if we wanted one.
+
+                    // This tooltip is useful when there are a lot of captures.
+                    hint.tooltip = new vscode.MarkdownString(`Captures: ${response.captureText}`);
                     hint.paddingRight = true;
                     hint.paddingLeft = false;
                     inlayHintCache[document.uri.toString()].push(hint);


### PR DESCRIPTION
Very WIP, but here are a few screenshots:

![image](https://github.com/user-attachments/assets/5334b6d9-82b2-4674-90df-eebf4ca07a2c)

<img width="494" alt="Screenshot 2024-11-07 at 22 46 59" src="https://github.com/user-attachments/assets/1f925326-04f4-46a6-a9f8-69785860f191">
<img width="706" alt="Screenshot 2024-11-07 at 22 46 30" src="https://github.com/user-attachments/assets/45027788-2c3a-4fbc-abba-c72d5467f26f">



A short-term goal is to retire the current hacky implementation of rendering inferred captures (by using inlay hints instead).
A long-term goal would be to use inlay hints as a proper mechanism on the server side (relevant to https://github.com/effekt-lang/effekt/issues/524) 

Resolves #32 (mostly by accident)

Current issues / TODOs:
- [ ] I have no idea how the `inferredCaptures` API works, sometimes it's weirdly invalidated? (If I figure out what I should want, we could even change the Effekt compiler here...)
- [ ] The editor currently asks for the captures very often, can we only ask for them on save?
- [ ] Re-add `showCaptures`, add to docs that one needs to enable inlay hints in the editor globally (as a feature)
- [x] Remove the leftover commented-out code
- [ ] Remove the DEBUG logger
- [ ] Take a look if the `holes` code can also be replaced by this perhaps? (probably not though)