### PR TITLE
Removed invalid 'clear' from Runner

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,9 +56,7 @@ async function runEffektFile(uri: vscode.Uri) {
     const effektExecutable = await effektManager.locateEffektExecutable();
     const args = [ uri.fsPath, ...effektManager.getEffektArgs() ];
 
-    // Clear the terminal using API Call
-    await vscode.commands.executeCommand('workbench.action.terminal.clear');
-
+    terminal.sendText(process.platform === 'win32' ? 'cls' : 'clear');
     terminal.sendText(`${effektExecutable.path} ${args.join(' ')}`);
     terminal.show();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,9 @@ async function runEffektFile(uri: vscode.Uri) {
     const effektExecutable = await effektManager.locateEffektExecutable();
     const args = [ uri.fsPath, ...effektManager.getEffektArgs() ];
 
-    terminal.sendText("clear");
+    // Clear the terminal using API Call
+    await vscode.commands.executeCommand('workbench.action.terminal.clear');
+
     terminal.sendText(`${effektExecutable.path} ${args.join(' ')}`);
     terminal.show();
 }


### PR DESCRIPTION
## Motivation
Removed the invalid call of `clear` for the terminal when running a Effekt-file via the extension
Resolves #41

## Changes
- removed invalid `sendText("clear")`, which caused an error as `clear` is not a valid windows command
- added a VSCode API call `executeCommand('workbench.action.terminal.clear')`, which should perform the `clear` operation platform independent

