### PR TITLE
 Fix comment rendering in function definitions

### DIFF
--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -38,7 +38,8 @@
     "definitions": {
       "patterns": [{
           "begin": "\\s*(extern)\\s+((?:(?:\\{[^\\}]*\\}|[a-zA-Z][a-z-A-Z0-9_$]*)\\s+)?)\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
+          "end": "(?=//|\\n)|(?<=\\S)\\s*(?==(?!>))"
+,
           "captures": {
             "1": { "name": "storage.modifier.extern.effekt" },
             "2": { "patterns": [{ "include": "#capabilities" }] },
@@ -48,7 +49,8 @@
           "patterns": [{ "include": "#parameters" }]
         }, {
           "begin": "\\s*(def)\\s+([a-zA-Z][a-z-A-Z0-9_$]*)\\b",
-          "end": "(?=\\n)|(?<=\\S)\\s*(?==(?!>))",
+          "end": "(?=//|\\n)|(?<=\\S)\\s*(?==(?!>))"
+,
           "captures": {
             "1": { "name": "keyword.declaration.function.effekt" },
             "2": { "name": "entity.name.function.effekt" }


### PR DESCRIPTION

**Problem:**
Comments after function signatures were not highlighted properly, since the function parsing rule was consuming too much text.

**Fix:**
Adjusted the `end` pattern in `definitions` to stop at `//`, allowing the comment rule to apply correctly.

**Change:**
Added the `//` chars to the end rule : 
```json
"end": "(?=//|\n)|(?<=\\S)\\s*(?==(?!>))"
```

**Tested:** Works after reloading VSCode with the examples:

<div style="display: flex; gap: 10px;">
  <div>
    <p><strong>Before:</strong></p>
    <img src="https://github.com/user-attachments/assets/69ea60c7-3774-4ce7-9dd7-14453e567dd5" alt="Before" width="600"/>
  </div>
  <div>
    <p><strong>With changes:</strong></p>
    <img src="https://github.com/user-attachments/assets/2184834f-95f8-48d7-89fc-18ee7545b5cc" alt="With changes" width="600"/>
  </div>
</div>

---
Now, `//` renders as an actual comment. ✨
