### PR TITLE
Add changelog link prompt after Effekt update

### DIFF
--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -337,17 +337,23 @@ export class EffektManager {
         const response = await vscode.window.showInformationMessage(message, 'Yes', 'No');
         if (response === 'Yes') {
             const installedVersion = await this.installOrUpdateEffekt(version, action);
-            if(!!installedVersion){
-                // After installation or update is complete, offer to open the changelog
-                const changelogMessage = `Effekt ${installedVersion} has been updated. Would you like to view the changelog?`;
-                const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, 'Yes', 'No');
-
-                if (changelogResponse === 'Yes') {
+            if (!!installedVersion) {
+                const isUpdate = action === 'update';
+                const actionCompleted = isUpdate ? 'updated' : 'installed';
+                const changelogMessage = `Effekt ${installedVersion} has been ${actionCompleted}`;
+            
+                const options = isUpdate ? ['View Release Notes', 'Close'] : ['View Language Introduction', 'Close'];
+                const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, ...options);
+            
+                if (changelogResponse === 'View Release Notes') {
                     const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${installedVersion}`;
                     vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
+                } else if (changelogResponse === 'View Language Introduction') {
+                    const introUrl = 'https://effekt-lang.org/docs/introduction';
+                    vscode.env.openExternal(vscode.Uri.parse(introUrl));
                 }
             }
-        }
+        }            
         this.updateStatusBar();
         return this.effektVersion || '';
     }

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -337,7 +337,7 @@ export class EffektManager {
         const response = await vscode.window.showInformationMessage(message, 'Yes', 'No');
         if (response === 'Yes') {
             const installedVersion = await this.installOrUpdateEffekt(version, action);
-            if(installedVersion != ''){
+            if(!!installedVersion){
                 // After installation or update is complete, offer to open the changelog
                 const changelogMessage = `Effekt ${installedVersion} has been updated. Would you like to view the changelog?`;
                 const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, 'Yes', 'No');

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -307,19 +307,7 @@ export class EffektManager {
 
             // check if the latest version strictly newer than the current version
             if (!this.effektVersion || compareVersion(latestVersion, this.effektVersion, '>')) {
-                const installedVersion = await this.promptForAction(latestVersion, 'update');
-                if(installedVersion != ''){
-                    // After installation or update is complete, offer to open the changelog
-                    const changelogMessage = `Effekt ${installedVersion} has been updated. Would you like to view the changelog?`;
-                    const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, 'Yes', 'No');
-
-                    if (changelogResponse === 'Yes') {
-                        const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${installedVersion}`;
-                        vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
-                    }
-                }
-                return installedVersion;
-                
+                return  this.promptForAction(latestVersion, 'update');
             }
 
             this.updateStatusBar();
@@ -348,7 +336,17 @@ export class EffektManager {
 
         const response = await vscode.window.showInformationMessage(message, 'Yes', 'No');
         if (response === 'Yes') {
-            return this.installOrUpdateEffekt(version, action);
+            const installedVersion = await this.installOrUpdateEffekt(version, action);
+            if(installedVersion != ''){
+                // After installation or update is complete, offer to open the changelog
+                const changelogMessage = `Effekt ${installedVersion} has been updated. Would you like to view the changelog?`;
+                const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, 'Yes', 'No');
+
+                if (changelogResponse === 'Yes') {
+                    const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${installedVersion}`;
+                    vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
+                }
+            }
         }
         this.updateStatusBar();
         return this.effektVersion || '';

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -307,7 +307,19 @@ export class EffektManager {
 
             // check if the latest version strictly newer than the current version
             if (!this.effektVersion || compareVersion(latestVersion, this.effektVersion, '>')) {
-                return this.promptForAction(latestVersion, 'update');
+                const installedVersion = await this.promptForAction(latestVersion, 'update');
+                if(installedVersion != ''){
+                    // After installation or update is complete, offer to open the changelog
+                    const changelogMessage = `Effekt ${installedVersion} has been updated. Would you like to view the changelog?`;
+                    const changelogResponse = await vscode.window.showInformationMessage(changelogMessage, 'Yes', 'No');
+
+                    if (changelogResponse === 'Yes') {
+                        const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${installedVersion}`;
+                        vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
+                    }
+                }
+                return installedVersion;
+                
             }
 
             this.updateStatusBar();

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -307,7 +307,7 @@ export class EffektManager {
 
             // check if the latest version strictly newer than the current version
             if (!this.effektVersion || compareVersion(latestVersion, this.effektVersion, '>')) {
-                return  this.promptForAction(latestVersion, 'update');
+                return this.promptForAction(latestVersion, 'update');
             }
 
             this.updateStatusBar();


### PR DESCRIPTION
## Description
This PR adds a feature to the Effekt version update flow. After successfully updating the Effekt version, the user is prompted with an option to view the changelog for the new version. If the user chooses "Yes," their browser will open to the changelog page for the respective version on GitHub

## Changes
- Modified the `promptForAction` method to offer the user the option to view the changelog after an successfull update.
- If the user accepts, it opens the changelog URL in their default browser.

## How to test
1. Run the extension in debug mode (`F5`).
2. Press Yes when prompted to update your Effekt version
3. When the update/install completes, a prompt will appear asking if you want to view the changelog.
4. Clicking "Yes" should open the changelog page in your browser.

## Related Issues
- #42: Provide changelog link after version update
