### PR TITLE
Show info popup when Effekt is up-to-date

### DIFF
--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -308,6 +308,8 @@ export class EffektManager {
             // check if the latest version strictly newer than the current version
             if (!this.effektVersion || compareVersion(latestVersion, this.effektVersion, '>')) {
                 return this.promptForAction(latestVersion, 'update');
+            } else {
+                vscode.window.showInformationMessage(`Effekt is up-to-date (version ${this.effektVersion}).`);
             }
 
             this.updateStatusBar();


### PR DESCRIPTION
I was missing some visual feedback when pressing the Effekt button in the status bar when the Effekt version is up-to-date. This is how it looks like after this PR:

![image](https://github.com/user-attachments/assets/7ad44264-055d-4233-86fb-d6db97e99f0a)
