### PR TITLE
Remove depcrecated lifted-core option from the showIR dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,6 @@
                         "none",
                         "source",
                         "core",
-                        "lifted-core",
                         "machine",
                         "target"
                     ],
@@ -132,7 +131,6 @@
                         "Disable showing intermediate representation.",
                         "Show source tree after parsing.",
                         "Show the core intermediate representation after capability-passing transformation.",
-                        "Show the core intermediate representation after lift inference.",
                         "Show the machine representation.",
                         "Show the generated code in the target language."
                     ]


### PR DESCRIPTION
As suggested in #36, the `lifted-core` option is deprecated, and it’s time to remove it altogether.

#### Changes:
- Removed `lifted-core` from the `enum` and `enumDescriptions` in the `effekt.showIR` configuration.
- Updated the default behavior to ensure no issues arise from the removal.

The extension now does not show this option in the settings and still works as expected