### PR TITLE
Refactor LSP Initialization to Avoid Blocking on Update Prompt

### DIFF
--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -83,6 +83,11 @@ export class EffektManager {
         throw new Error("Unable to determine Effekt version");
     }
 
+    // DRAFT HELPER 
+    public async getEffektVersion(): Promise<string> {
+        return this.effektVersion || '';
+    }
+
     /**
      * Executes a shell command and returns the output.
      * @param command The command to execute.

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -83,7 +83,7 @@ export class EffektManager {
         throw new Error("Unable to determine Effekt version");
     }
 
-    // DRAFT HELPER 
+    // THIS SHOULD BE HANDLED DIFFERENTLY! 
     public async getEffektVersion(): Promise<string> {
         return this.effektVersion || '';
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,8 +228,10 @@ function registerIRProvider(context: vscode.ExtensionContext) {
     });
 }
 
-// Initialize hole decorations
-function initializeHoleDecorations(context: vscode.ExtensionContext) {
+    // Decorate holes
+    // ---
+    // It would be nice if there was a way to reuse the scopes of the tmLanguage file
+    function initializeHoleDecorations(context: vscode.ExtensionContext) {
     const holeDelimiterDecoration = vscode.window.createTextEditorDecorationType({
         opacity: '0.5',
         borderRadius: '4pt',
@@ -237,6 +239,7 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
         dark: { backgroundColor: "rgba(255,255,255,0.05)" }
     });
 
+    // based on https://github.com/microsoft/vscode-extension-samples/blob/master/decorator-sample/src/extension.ts
     let timeout: NodeJS.Timeout;
     let editor = vscode.window.activeTextEditor;
 
@@ -246,7 +249,10 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
     }
 
     const holeRegex = /<>|<{|}>/g;
-
+    
+    /**
+     * TODO clean this up -- ideally move it to the language server
+     */
     function updateHoles() {
         if (!editor) { return; }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,7 +115,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const effektVersion = await effektManager.checkForUpdatesAndInstall();
     if (!effektVersion) {
         vscode.window.showWarningMessage('Effekt is not installed. LSP features may not work correctly.');
-    } else if (effektVersion !== await effektManager.getEffektVersion()) {
+    } else if (effektVersion !== await effektManager.getEffektVersion() /* THIS SHOULD BE REMOVED */) { 
         // If the version was updated, restart the server
         await restartEffektLanguageServer(context);
     } else {


### PR DESCRIPTION
## Overview

This pull request refactors the LSP initialization process.. The goal is to ensure that the LSP starts immediately with the currently installed version, even if the user has not yet responded to the update prompt. This prevents the update dialog from halting the LSP functionality.

## Changes Summary

### Key Changes
1. **Immediate LSP Initialization**:
   - The LSP is now started immediately during the `activate` function, using the current version of Effekt. This ensures that the extension's features are available without waiting for the user to respond to the update prompt.

2. **Refactored Update Workflow**:
   - The update prompt is decoupled from the LSP initialization. After starting the LSP, the extension checks for updates. If an update is available and the user confirms, the LSP is restarted with the updated version.

3. **Logic Modularized**:
   -  Logics (e.g. Hole Decorations), originally embedded in the `activate` function, have been extracted into a new function. This improves code readability and maintainability.

4. **Improved Code Structure**:
   - Commands, CodeLens providers, and IR providers are registered before checking for updates. This ensures that these features are immediately available to the user.


## Benefits

- **Improved User Experience**:
  - Users can immediately utilize the LSP features without waiting for the update prompt.
- **Code Readability**:
  - Decoupled logic and modularized functions enhance code clarity and maintainability.
- **Backward Compatibility**:
  - The existing functionality of the extension remains intact

## Problems / TODO:
- there is a very very hacky way of retrieving the Effekt Version from the effekt manager which included a ugly new get function. This should be removed
- test if the reststart works like intended
## Additional Context

This Draft addresses issue #67 