### PR TITLE
Add ESLint and Prettier as linter and formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.vsix
 .vscodeignore
 effekt-*.tgz
+tsconfig.tsbuildinfo

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "printWidth": 80
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,40 @@
+/**
+ * ESLint configuration for the project.
+ * 
+ * See https://eslint.style and https://typescript-eslint.io for additional linting options.
+ */
+// @ts-check
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+	{
+		ignores: [
+			'**/.vscode-test',
+			'**/out',
+		]
+	},
+	js.configs.recommended,
+	...tseslint.configs.recommended,
+	...tseslint.configs.stylistic,
+	{
+		
+		rules: {
+			'curly': 'warn',
+			'@typescript-eslint/no-empty-function': 'off',
+			'@typescript-eslint/naming-convention': [
+				'warn',
+				{
+					'selector': 'import',
+					'format': ['camelCase', 'PascalCase']
+				}
+			],
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					'argsIgnorePattern': '^_'
+				}
+			]
+		}
+	}
+);

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-        "lint": "eslint ./client/src ./server/src --ext .ts,.tsx"
+        "lint": "eslint"
     },
     "dependencies": {
         "compare-versions": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,10 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-        "lint": "eslint"
+        "lint": "eslint",
+        "lint:fix": "eslint --fix",
+        "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"
+
     },
     "dependencies": {
         "compare-versions": "^6.1.1",

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/effektManager.ts","./src/extension.ts","./src/inlayHintsProvider.ts","./src/irProvider.ts"],"version":"5.8.3"}

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/effektManager.ts","./src/extension.ts","./src/inlayHintsProvider.ts","./src/irProvider.ts"],"version":"5.8.3"}


### PR DESCRIPTION
This PR introduces 
- ESLint as a linter (`npx eslint .`  or  `npm run lint .`  and `npm run lint:fix .` )
- Prettier as a formatter (`npm run prettier-format`) 