### PR TITLE
Add ESLint and Prettier as linter and formatter

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# .git-blame-ignore-revs
+
+# using `git blame --ignore-revs-file .git-blame-ignore-revs`
+# or configuring git to always do so : `git config blame.ignoreRevsFile .git-blame-ignore-revs`
+
+
+# First time linting and formatting the whole codebase
+87e78e4db73d7f28aad21613bc64ed1ea80c4d6d

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # First time linting and formatting the whole codebase
 87e78e4db73d7f28aad21613bc64ed1ea80c4d6d
+
+# Reformat with trailing commata on 
+0c41364313629aa1cf42c0b1f40c3f78c7e48196

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,11 @@ jobs:
     - run: npm install -g vsce
     - run: npm install
 
+    - name: Run ESLint
+      run: npm run lint
+
+    - name: Run Prettier Check
+      run: npm run format:check
+      
     - name: Package VSCode extension into .vsix file
       run: vsce package

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "printWidth": 80
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": true,
-  "trailingComma": "none",
+  "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 80
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,48 @@
+/**
+ * ESLint configuration for the project.
+ * 
+ * See https://eslint.style and https://typescript-eslint.io for additional linting options.
+ */
+// @ts-check
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+import prettierPlugin from 'eslint-plugin-prettier';
+
+export default tseslint.config(
+    {
+        ignores: [
+            '**/.vscode-test',
+            '**/out',
+        ]
+    },
+    js.configs.recommended,
+    ...tseslint.configs.recommended,
+    ...tseslint.configs.stylistic,
+    prettier, // Disable conflicting ESLint rules
+    {
+        plugins: {
+            prettier: prettierPlugin // Enable Prettier plugin
+        },
+        rules: {
+            'prettier/prettier': 'error', // Treat Prettier issues as ESLint errors
+            'curly': 'warn',
+            '@typescript-eslint/no-empty-function': 'off',
+            '@typescript-eslint/naming-convention': [
+                'warn',
+                {
+                    'selector': 'import',
+                    'format': ['camelCase', 'PascalCase']
+                }
+            ],
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    'argsIgnorePattern': '^_', // Allow unused variables with a prefix '_'
+                    'varsIgnorePattern': '^_'  // Allow unused vars with a prefix '_'
+                }
+            ],
+            '@typescript-eslint/no-explicit-any': 'off' // Allow 'any' type
+        }
+    }
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
                 "@typescript-eslint/eslint-plugin": "^7.1.0",
                 "@typescript-eslint/parser": "^7.1.0",
                 "eslint": "^8.57.1",
+                "eslint-config-prettier": "^10.1.5",
+                "eslint-plugin-prettier": "^5.4.0",
                 "mocha": "^10.3.0",
                 "prettier": "^3.5.3",
                 "typescript": "^5.8.3",
@@ -155,6 +157,18 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@pkgr/core": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+            "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/pkgr"
             }
         },
         "node_modules/@types/mocha": {
@@ -826,6 +840,51 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/eslint-config-prettier": {
+            "version": "10.1.5",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+            "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/eslint-plugin-prettier": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
+            "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
+            "dev": true,
+            "dependencies": {
+                "prettier-linter-helpers": "^1.0.0",
+                "synckit": "^0.11.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-plugin-prettier"
+            },
+            "peerDependencies": {
+                "@types/eslint": ">=8.0.0",
+                "eslint": ">=8.0.0",
+                "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+                "prettier": ">=3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/eslint": {
+                    "optional": true
+                },
+                "eslint-config-prettier": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/eslint-scope": {
             "version": "7.2.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -926,6 +985,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "node_modules/fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true
         },
         "node_modules/fast-glob": {
@@ -1666,6 +1731,18 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/prettier-linter-helpers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "dev": true,
+            "dependencies": {
+                "fast-diff": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1906,6 +1983,22 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/synckit": {
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.5.tgz",
+            "integrity": "sha512-frqvfWyDA5VPVdrWfH24uM6SI/O8NLpVbIIJxb8t/a3YGsp4AW9CYgSKC0OaSEfexnp7Y1pVh2Y6IHO8ggGDmA==",
+            "dev": true,
+            "dependencies": {
+                "@pkgr/core": "^0.2.4",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/synckit"
+            }
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -1935,6 +2028,12 @@
             "peerDependencies": {
                 "typescript": ">=4.2.0"
             }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -2498,6 +2597,12 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@pkgr/core": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+            "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+            "dev": true
+        },
         "@types/mocha": {
             "version": "10.0.7",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
@@ -2970,6 +3075,23 @@
                 }
             }
         },
+        "eslint-config-prettier": {
+            "version": "10.1.5",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+            "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+            "dev": true,
+            "requires": {}
+        },
+        "eslint-plugin-prettier": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.4.0.tgz",
+            "integrity": "sha512-BvQOvUhkVQM1i63iMETK9Hjud9QhqBnbtT1Zc642p9ynzBuCe5pybkOnvqZIBypXmMlsGcnU4HZ8sCTPfpAexA==",
+            "dev": true,
+            "requires": {
+                "prettier-linter-helpers": "^1.0.0",
+                "synckit": "^0.11.0"
+            }
+        },
         "eslint-scope": {
             "version": "7.2.2",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -3031,6 +3153,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-diff": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+            "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
             "dev": true
         },
         "fast-glob": {
@@ -3583,6 +3711,15 @@
             "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
             "dev": true
         },
+        "prettier-linter-helpers": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "dev": true,
+            "requires": {
+                "fast-diff": "^1.1.2"
+            }
+        },
         "punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3725,6 +3862,16 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "synckit": {
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.5.tgz",
+            "integrity": "sha512-frqvfWyDA5VPVdrWfH24uM6SI/O8NLpVbIIJxb8t/a3YGsp4AW9CYgSKC0OaSEfexnp7Y1pVh2Y6IHO8ggGDmA==",
+            "dev": true,
+            "requires": {
+                "@pkgr/core": "^0.2.4",
+                "tslib": "^2.8.1"
+            }
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3746,6 +3893,12 @@
             "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
             "dev": true,
             "requires": {}
+        },
+        "tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "type-check": {
             "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,29 +12,35 @@
                 "vscode-languageclient": "^8.1.0"
             },
             "devDependencies": {
+                "@eslint/js": "^9.26.0",
                 "@types/mocha": "^10.0.6",
                 "@types/node": "^20.11.25",
                 "@types/vscode": "^1.80.0",
                 "@typescript-eslint/eslint-plugin": "^7.1.0",
                 "@typescript-eslint/parser": "^7.1.0",
-                "eslint": "^8.57.0",
+                "eslint": "^8.57.1",
                 "mocha": "^10.3.0",
-                "typescript": "^5.3.3"
+                "prettier": "^3.5.3",
+                "typescript": "^5.8.3",
+                "typescript-eslint": "^8.32.1"
             },
             "engines": {
                 "vscode": "^1.80.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+            "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
             "dev": true,
             "dependencies": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -73,22 +79,22 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+            "version": "9.26.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+            "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
             "dev": true,
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.14",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.2",
+                "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             },
@@ -765,16 +771,17 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.0",
-                "@humanwhocodes/config-array": "^0.11.14",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -845,6 +852,15 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/@eslint/js": {
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+            "dev": true,
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/espree": {
@@ -1635,6 +1651,21 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prettier": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "dev": true,
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1930,9 +1961,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -1940,6 +1971,257 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+            "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.32.1",
+                "@typescript-eslint/parser": "8.32.1",
+                "@typescript-eslint/utils": "8.32.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+            "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.32.1",
+                "@typescript-eslint/type-utils": "8.32.1",
+                "@typescript-eslint/utils": "8.32.1",
+                "@typescript-eslint/visitor-keys": "8.32.1",
+                "graphemer": "^1.4.0",
+                "ignore": "^7.0.0",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+            "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.32.1",
+                "@typescript-eslint/types": "8.32.1",
+                "@typescript-eslint/typescript-estree": "8.32.1",
+                "@typescript-eslint/visitor-keys": "8.32.1",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+            "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.32.1",
+                "@typescript-eslint/visitor-keys": "8.32.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+            "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.32.1",
+                "@typescript-eslint/utils": "8.32.1",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+            "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+            "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.32.1",
+                "@typescript-eslint/visitor-keys": "8.32.1",
+                "debug": "^4.3.4",
+                "fast-glob": "^3.3.2",
+                "is-glob": "^4.0.3",
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^2.1.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+            "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.32.1",
+                "@typescript-eslint/types": "8.32.1",
+                "@typescript-eslint/typescript-estree": "8.32.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.9.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+            "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "8.32.1",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/ignore": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+            "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/ts-api-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=18.12"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/undici-types": {
@@ -2130,12 +2412,12 @@
     },
     "dependencies": {
         "@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+            "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             }
         },
         "@eslint-community/regexpp": {
@@ -2162,18 +2444,18 @@
             }
         },
         "@eslint/js": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+            "version": "9.26.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.26.0.tgz",
+            "integrity": "sha512-I9XlJawFdSMvWjDt6wksMCrgns5ggLNfFwFvnShsleWruvXM514Qxk8V246efTw+eo9JABvVz+u3q2RiAowKxQ==",
             "dev": true
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.14",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-            "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^2.0.2",
+                "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
                 "minimatch": "^3.0.5"
             }
@@ -2635,16 +2917,16 @@
             "dev": true
         },
         "eslint": {
-            "version": "8.57.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "dev": true,
             "requires": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.0",
-                "@humanwhocodes/config-array": "^0.11.14",
+                "@eslint/js": "8.57.1",
+                "@humanwhocodes/config-array": "^0.13.0",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -2678,6 +2960,14 @@
                 "optionator": "^0.9.3",
                 "strip-ansi": "^6.0.1",
                 "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "@eslint/js": {
+                    "version": "8.57.1",
+                    "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+                    "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+                    "dev": true
+                }
             }
         },
         "eslint-scope": {
@@ -3287,6 +3577,12 @@
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true
         },
+        "prettier": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+            "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+            "dev": true
+        },
         "punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3467,10 +3763,156 @@
             "dev": true
         },
         "typescript": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true
+        },
+        "typescript-eslint": {
+            "version": "8.32.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+            "integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/eslint-plugin": "8.32.1",
+                "@typescript-eslint/parser": "8.32.1",
+                "@typescript-eslint/utils": "8.32.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+                    "integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/regexpp": "^4.10.0",
+                        "@typescript-eslint/scope-manager": "8.32.1",
+                        "@typescript-eslint/type-utils": "8.32.1",
+                        "@typescript-eslint/utils": "8.32.1",
+                        "@typescript-eslint/visitor-keys": "8.32.1",
+                        "graphemer": "^1.4.0",
+                        "ignore": "^7.0.0",
+                        "natural-compare": "^1.4.0",
+                        "ts-api-utils": "^2.1.0"
+                    }
+                },
+                "@typescript-eslint/parser": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+                    "integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/scope-manager": "8.32.1",
+                        "@typescript-eslint/types": "8.32.1",
+                        "@typescript-eslint/typescript-estree": "8.32.1",
+                        "@typescript-eslint/visitor-keys": "8.32.1",
+                        "debug": "^4.3.4"
+                    }
+                },
+                "@typescript-eslint/scope-manager": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+                    "integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "8.32.1",
+                        "@typescript-eslint/visitor-keys": "8.32.1"
+                    }
+                },
+                "@typescript-eslint/type-utils": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+                    "integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/typescript-estree": "8.32.1",
+                        "@typescript-eslint/utils": "8.32.1",
+                        "debug": "^4.3.4",
+                        "ts-api-utils": "^2.1.0"
+                    }
+                },
+                "@typescript-eslint/types": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+                    "integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
+                    "dev": true
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+                    "integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "8.32.1",
+                        "@typescript-eslint/visitor-keys": "8.32.1",
+                        "debug": "^4.3.4",
+                        "fast-glob": "^3.3.2",
+                        "is-glob": "^4.0.3",
+                        "minimatch": "^9.0.4",
+                        "semver": "^7.6.0",
+                        "ts-api-utils": "^2.1.0"
+                    }
+                },
+                "@typescript-eslint/utils": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+                    "integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
+                    "dev": true,
+                    "requires": {
+                        "@eslint-community/eslint-utils": "^4.7.0",
+                        "@typescript-eslint/scope-manager": "8.32.1",
+                        "@typescript-eslint/types": "8.32.1",
+                        "@typescript-eslint/typescript-estree": "8.32.1"
+                    }
+                },
+                "@typescript-eslint/visitor-keys": {
+                    "version": "8.32.1",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+                    "integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "8.32.1",
+                        "eslint-visitor-keys": "^4.2.0"
+                    }
+                },
+                "brace-expansion": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+                    "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+                    "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "9.0.5",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+                    "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^2.0.1"
+                    }
+                },
+                "ts-api-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+                    "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+                    "dev": true,
+                    "requires": {}
+                }
+            }
         },
         "undici-types": {
             "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
         "lint:fix": "eslint 'src/**/*.ts' --fix",
         "format": "prettier --config .prettierrc 'src/**/*.ts' --write",
         "format:check": "prettier --config .prettierrc 'src/**/*.ts' --check"
-        },
+    },
     "dependencies": {
         "compare-versions": "^6.1.1",
         "vscode-languageclient": "^8.1.0"
@@ -203,6 +203,8 @@
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
         "eslint": "^8.57.1",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.4.0",
         "mocha": "^10.3.0",
         "prettier": "^3.5.3",
         "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -186,20 +186,26 @@
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -b",
         "watch": "tsc -b -w",
-        "lint": "eslint ./client/src ./server/src --ext .ts,.tsx"
-    },
+        "lint": "eslint 'src/**/*.ts'",
+        "lint:fix": "eslint 'src/**/*.ts' --fix",
+        "format": "prettier --config .prettierrc 'src/**/*.ts' --write",
+        "format:check": "prettier --config .prettierrc 'src/**/*.ts' --check"
+        },
     "dependencies": {
         "compare-versions": "^6.1.1",
         "vscode-languageclient": "^8.1.0"
     },
     "devDependencies": {
+        "@eslint/js": "^9.26.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.25",
         "@types/vscode": "^1.80.0",
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
-        "eslint": "^8.57.0",
+        "eslint": "^8.57.1",
         "mocha": "^10.3.0",
-        "typescript": "^5.3.3"
+        "prettier": "^3.5.3",
+        "typescript": "^5.8.3",
+        "typescript-eslint": "^8.32.1"
     }
 }

--- a/src/effektLanguageClient.ts
+++ b/src/effektLanguageClient.ts
@@ -3,10 +3,10 @@ import { LanguageClient } from 'vscode-languageclient/node';
 /*
  * Overrides the `registerFeature` method to disable the built-in inlay hints feature.
  *
- * By default the LanguageClient provides inlay hints automatically, which does not allow 
+ * By default the LanguageClient provides inlay hints automatically, which does not allow
  * for filtering Inlay Hints based on their 'data'-field. We use the 'data'-field to allow
  * the user to select which inlay hints the extension should show.
- * 
+ *
  * By doing this, we retain full control over how inlay hints are displayed, allowing us to
  * implement custom logic.
  *
@@ -14,10 +14,10 @@ import { LanguageClient } from 'vscode-languageclient/node';
  * (`InlayHintsFeature`). If the LSP implementation changes, this logic may need to be updated.
  */
 export class EffektLanguageClient extends LanguageClient {
-    public registerFeature(feature: any) {
-        if (feature.constructor.name === 'InlayHintsFeature') { 
-            return; 
-        }
-        super.registerFeature(feature);
+  public registerFeature(feature: any) {
+    if (feature.constructor.name === 'InlayHintsFeature') {
+      return;
     }
+    super.registerFeature(feature);
+  }
 }

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -45,14 +45,14 @@ export class EffektManager {
 
   constructor() {
     this.statusBarItem = vscode.window.createStatusBarItem(
-      vscode.StatusBarAlignment.Left
+      vscode.StatusBarAlignment.Left,
     );
     this.statusBarItem.text = 'Ξ Effekt';
     this.statusBarItem.command = 'effekt.checkForUpdates';
     this.statusBarItem.show();
     this.config = vscode.workspace.getConfiguration('effekt');
     this.outputChannel = vscode.window.createOutputChannel(
-      'Effekt Version Manager'
+      'Effekt Version Manager',
     );
     this.updateStatusBar();
   }
@@ -75,7 +75,7 @@ export class EffektManager {
       const version = removePrefix(versionOutput.trim(), 'Effekt '); // NOTE: the space is important here
       if (!version) {
         throw new Error(
-          `Output of '${path} --version' is not in the correct format 'Effekt 0.1.2'; got '${versionOutput}' instead.`
+          `Output of '${path} --version' is not in the correct format 'Effekt 0.1.2'; got '${versionOutput}' instead.`,
         );
       }
       return version;
@@ -91,7 +91,7 @@ export class EffektManager {
       } catch (helpError) {
         // If both `--version` and `--help` fail, throw an error
         throw new Error(
-          `Failed to determine Effekt version: ${versionError}\nHelp command also failed: ${helpError}`
+          `Failed to determine Effekt version: ${versionError}\nHelp command also failed: ${helpError}`,
         );
       }
     }
@@ -117,7 +117,7 @@ export class EffektManager {
    */
   private async execCommand(
     command: string,
-    resolveWithStderr?: boolean
+    resolveWithStderr?: boolean,
   ): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       cp.exec(
@@ -131,7 +131,7 @@ export class EffektManager {
               stdout.trim() + (resolveWithStderr ? stderr.trim() : '');
             resolve(output);
           }
-        }
+        },
       );
     });
   }
@@ -143,7 +143,7 @@ export class EffektManager {
    */
   private logMessage(level: 'INFO' | 'ERROR', message: string) {
     this.outputChannel.appendLine(
-      `[${new Date().toISOString()}] ${level}: ${message}`
+      `[${new Date().toISOString()}] ${level}: ${message}`,
     );
   }
 
@@ -165,14 +165,14 @@ export class EffektManager {
               resolve(json.version);
             } catch (error) {
               reject(
-                new Error(`Failed to parse npm registry response: ${error}`)
+                new Error(`Failed to parse npm registry response: ${error}`),
               );
             }
           });
         })
         .on('error', (error) => {
           reject(
-            new Error(`Failed to fetch latest version from npm: ${error}`)
+            new Error(`Failed to fetch latest version from npm: ${error}`),
           );
         });
     });
@@ -188,12 +188,12 @@ export class EffektManager {
         const version = await this.fetchEffektVersion(customEffektPath);
         this.logMessage(
           'INFO',
-          `Located executable at custom path ${customEffektPath} with version ${version}`
+          `Located executable at custom path ${customEffektPath} with version ${version}`,
         );
         return { path: customEffektPath, version };
       } catch (error) {
         this.showErrorWithLogs(
-          `Custom Effekt executable not working: ${customEffektPath}. ${error}`
+          `Custom Effekt executable not working: ${customEffektPath}. ${error}`,
         );
       }
     }
@@ -203,7 +203,7 @@ export class EffektManager {
         const version = await this.fetchEffektVersion(effektPath);
         this.logMessage(
           'INFO',
-          `Located executable at path ${effektPath} with version ${version}`
+          `Located executable at path ${effektPath} with version ${version}`,
         );
         return { path: effektPath, version };
       } catch {
@@ -221,7 +221,7 @@ export class EffektManager {
    */
   private async installOrUpdateEffekt(
     action: 'install' | 'update',
-    client?: EffektLanguageClient
+    client?: EffektLanguageClient,
   ): Promise<string> {
     if (!(await this.checkJava())) {
       this.logMessage('INFO', 'Java is not installed.');
@@ -236,7 +236,7 @@ export class EffektManager {
       {
         location: vscode.ProgressLocation.Notification,
         title: `${action === 'update' ? 'Updating' : 'Installing'} Effekt`,
-        cancellable: false
+        cancellable: false,
       },
       async (progress) => {
         try {
@@ -246,7 +246,7 @@ export class EffektManager {
           await this.runNpmInstall();
           progress.report({
             increment: 50,
-            message: 'Verifying installation...'
+            message: 'Verifying installation...',
           });
 
           const verificationResult = await this.verifyEffektInstallation();
@@ -265,7 +265,7 @@ export class EffektManager {
           await client?.start();
           return '';
         }
-      }
+      },
     );
   }
 
@@ -275,10 +275,10 @@ export class EffektManager {
     if (npmRoot.startsWith('/nix/store')) {
       this.logMessage(
         'ERROR',
-        'NPM root is in the read-only Nix store. Installation is not possible.'
+        'NPM root is in the read-only Nix store. Installation is not possible.',
       );
       throw new Error(
-        'Detected Nix environment: NPM global modules are stored in a read-only directory managed by Nix. Installation cannot proceed.'
+        'Detected Nix environment: NPM global modules are stored in a read-only directory managed by Nix. Installation cannot proceed.',
       );
     }
 
@@ -296,7 +296,7 @@ export class EffektManager {
         success: true,
         executable: execPath,
         message: `Effekt found successfully in ${execPath}.`,
-        version
+        version,
       };
     } catch {
       // If locateEffektExecutable fails, try to locate in global npm directory
@@ -311,7 +311,7 @@ export class EffektManager {
               success: true,
               executable: fullPath,
               message: `Effekt found at ${fullPath}, but not in PATH.`,
-              version
+              version,
             };
           } catch {
             // Executable exists but doesn't work, continue to next
@@ -322,7 +322,7 @@ export class EffektManager {
       return {
         success: false,
         message:
-          "Effekt was installed but couldn't be located or executed. Please check your installation."
+          "Effekt was installed but couldn't be located or executed. Please check your installation.",
       };
     }
   }
@@ -338,7 +338,7 @@ export class EffektManager {
 
   private async handleInstallationResult(
     result: InstallationResult,
-    action: 'install' | 'update'
+    action: 'install' | 'update',
   ): Promise<void> {
     if (result.success && result.version) {
       const baseMessage = `Effekt has been ${action === 'update' ? 'updated' : 'installed'} to version ${result.version}.`;
@@ -352,7 +352,7 @@ export class EffektManager {
           : ['View Language Introduction', 'Close'];
         const changelogResponse = await vscode.window.showInformationMessage(
           baseMessage,
-          ...options
+          ...options,
         );
 
         if (changelogResponse === 'View Release Notes') {
@@ -387,12 +387,12 @@ export class EffektManager {
    * @returns A promise that resolves with the current Effekt version.
    */
   public async checkForUpdatesAndInstall(
-    client?: EffektLanguageClient
+    client?: EffektLanguageClient,
   ): Promise<string> {
     try {
       const currentVersion = await this.getEffektVersion();
       const latestVersion = await this.getLatestNPMVersion(
-        this.effektNPMPackage
+        this.effektNPMPackage,
       );
 
       // check if the latest version strictly newer than the current version
@@ -403,7 +403,7 @@ export class EffektManager {
         return this.promptForAction(latestVersion, 'update', client);
       } else {
         vscode.window.showInformationMessage(
-          `Effekt is up-to-date (version ${currentVersion}).`
+          `Effekt is up-to-date (version ${currentVersion}).`,
         );
       }
 
@@ -415,7 +415,7 @@ export class EffektManager {
         error.message.includes('Effekt executable not found')
       ) {
         const latestVersion = await this.getLatestNPMVersion(
-          this.effektNPMPackage
+          this.effektNPMPackage,
         );
         return this.promptForAction(latestVersion, 'install', client);
       } else {
@@ -434,7 +434,7 @@ export class EffektManager {
   private async promptForAction(
     version: string,
     action: 'install' | 'update',
-    client?: EffektLanguageClient
+    client?: EffektLanguageClient,
   ): Promise<string> {
     const message =
       action === 'update'
@@ -444,7 +444,7 @@ export class EffektManager {
     const response = await vscode.window.showInformationMessage(
       message,
       'Yes',
-      'No'
+      'No',
     );
     if (response === 'Yes') {
       return this.installOrUpdateEffekt(action, client);
@@ -466,7 +466,7 @@ export class EffektManager {
 
       if (compareVersion(nodeVersion, minNodeVersion, '<')) {
         this.showErrorWithLogs(
-          `Node.js version ${minNodeVersion} or higher is required. You have ${nodeVersion}.`
+          `Node.js version ${minNodeVersion} or higher is required. You have ${nodeVersion}.`,
         );
         return false;
       }
@@ -477,7 +477,7 @@ export class EffektManager {
     } catch {
       this.showErrorWithLogs(
         'Node.js and npm are required to install Effekt automatically. ' +
-          'Please install Node.js (which includes npm), then restart VSCode.'
+          'Please install Node.js (which includes npm), then restart VSCode.',
       );
       return false;
     }
@@ -494,7 +494,7 @@ export class EffektManager {
 
       if (compareVersion(javaVersion, minJavaVersion, '<')) {
         this.showErrorWithLogs(
-          `Java version ${minJavaVersion} or higher is required. You have ${javaVersion}.`
+          `Java version ${minJavaVersion} or higher is required. You have ${javaVersion}.`,
         );
         return false;
       }
@@ -507,7 +507,7 @@ export class EffektManager {
 
       this.showErrorWithLogs(
         'Java (JRE) is required to run Effekt. ' +
-          'Please install Java, then restart VSCode.'
+          'Please install Java, then restart VSCode.',
       );
       return false;
     }
@@ -527,7 +527,7 @@ export class EffektManager {
       const versionRegexes = [
         /version "((\d+\.\d+\.\d+).*?)"/, // Standard format: "11.0.2" or "1.8.0_292"
         /version "((\d+).*?)"/, // OpenJDK format on some systems: "11" or "11-internal"
-        /(\d+\.\d+\.\d+)/ // Fallback for version without quotes
+        /(\d+\.\d+\.\d+)/, // Fallback for version without quotes
       ];
 
       let version = '';
@@ -591,7 +591,7 @@ export class EffektManager {
    * @param status The new server status.
    */
   public updateServerStatus(
-    status: 'starting' | 'running' | 'stopped' | 'error'
+    status: 'starting' | 'running' | 'stopped' | 'error',
   ) {
     this.serverStatus = status;
     this.updateStatusBar();
@@ -606,26 +606,26 @@ export class EffektManager {
         icon: '$(loading~spin) ',
         tooltip: 'Effekt server is starting...',
         color: undefined,
-        bgColor: undefined
+        bgColor: undefined,
       },
       running: {
         icon: '$(check) ',
         tooltip: 'Effekt server is running.',
         color: undefined,
-        bgColor: undefined
+        bgColor: undefined,
       },
       stopped: {
         icon: '$(stop-circle) ',
         tooltip: 'Effekt server is stopped.',
         color: 'statusBarItem.warningForeground',
-        bgColor: 'statusBarItem.warningBackground'
+        bgColor: 'statusBarItem.warningBackground',
       },
       error: {
         icon: '$(error) ',
         tooltip: 'Effekt server encountered an error.',
         color: 'statusBarItem.errorForeground',
-        bgColor: 'statusBarItem.errorBackground'
-      }
+        bgColor: 'statusBarItem.errorBackground',
+      },
     };
 
     const config = statusConfig[this.serverStatus];
@@ -637,7 +637,7 @@ export class EffektManager {
         `**Effekt Information:**\n` +
         `- Version: ${this.effektVersion || '<unknown>'}\n` +
         `- Status: ${this.serverStatus}\n` +
-        `- Backend: ${this.config.get<string>('backend') || '<unknown>'}`
+        `- Backend: ${this.config.get<string>('backend') || '<unknown>'}`,
     );
     this.statusBarItem.tooltip.isTrusted = true;
 

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -8,552 +8,672 @@ import * as fs from 'fs/promises';
 import { EffektLanguageClient } from './effektLanguageClient';
 
 interface InstallationResult {
-    success: boolean;
-    executable?: string;
-    message: string;
-    version?: string;
+  success: boolean;
+  executable?: string;
+  message: string;
+  version?: string;
 }
 
 interface EffektExecutableInfo {
-    path: string;
-    version: string;
+  path: string;
+  version: string;
 }
 
 export class EffektExecutableNotFoundError extends Error {
-    constructor(message: string = "Effekt executable not found") {
-        super(message);
-        this.name = "EffektExecutableNotFoundError";
-    }
+  constructor(message = 'Effekt executable not found') {
+    super(message);
+    this.name = 'EffektExecutableNotFoundError';
+  }
 }
 
 /**
  * Manages Effekt installation, updates, and status within VS Code.
  */
 export class EffektManager {
-    private statusBarItem: vscode.StatusBarItem;
-    private config: vscode.WorkspaceConfiguration;
-    private serverStatus: 'starting' | 'running' | 'stopped' | 'error' = 'stopped';
-    private outputChannel: vscode.OutputChannel;
-    private effektVersion: string | null = null;
+  private statusBarItem: vscode.StatusBarItem;
+  private config: vscode.WorkspaceConfiguration;
+  private serverStatus: 'starting' | 'running' | 'stopped' | 'error' =
+    'stopped';
+  private outputChannel: vscode.OutputChannel;
+  private effektVersion: string | null = null;
 
-    private readonly effektNPMPackage: string = '@effekt-lang/effekt';
-    private readonly possibleEffektExecutables =
-        process.platform === 'win32'
-            ? ['effekt.cmd', 'effekt', 'effekt.sh']  // On Windows, try 'effekt.cmd' first.
-            : ['effekt', 'effekt.sh', 'effekt.cmd'];
+  private readonly effektNPMPackage: string = '@effekt-lang/effekt';
+  private readonly possibleEffektExecutables =
+    process.platform === 'win32'
+      ? ['effekt.cmd', 'effekt', 'effekt.sh'] // On Windows, try 'effekt.cmd' first.
+      : ['effekt', 'effekt.sh', 'effekt.cmd'];
 
-    constructor() {
-        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-        this.statusBarItem.text = 'Ξ Effekt';
-        this.statusBarItem.command = 'effekt.checkForUpdates';
-        this.statusBarItem.show();
-        this.config = vscode.workspace.getConfiguration("effekt");
-        this.outputChannel = vscode.window.createOutputChannel("Effekt Version Manager");
-        this.updateStatusBar();
-    }
+  constructor() {
+    this.statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left
+    );
+    this.statusBarItem.text = 'Ξ Effekt';
+    this.statusBarItem.command = 'effekt.checkForUpdates';
+    this.statusBarItem.show();
+    this.config = vscode.workspace.getConfiguration('effekt');
+    this.outputChannel = vscode.window.createOutputChannel(
+      'Effekt Version Manager'
+    );
+    this.updateStatusBar();
+  }
 
-    /**
-     * Get the Effekt version of the (assumed) Effekt binary in the `path` parameter.
-     * Doesn't handle any errors, the *caller* is expected to do so.
-     *
-     * @returns a version number like '0.2.2' or '0.25.2.13' or '0.99.99+nightly.rev.abcdef', etc.
-     */
-    private async fetchEffektVersion(path: string): Promise<string> {
-        /// Helper function to remove a generic prefix from a string
-        const removePrefix = (value: string, prefix: string) =>
-            value.startsWith(prefix) ? value.slice(prefix.length) : null;
+  /**
+   * Get the Effekt version of the (assumed) Effekt binary in the `path` parameter.
+   * Doesn't handle any errors, the *caller* is expected to do so.
+   *
+   * @returns a version number like '0.2.2' or '0.25.2.13' or '0.99.99+nightly.rev.abcdef', etc.
+   */
+  private async fetchEffektVersion(path: string): Promise<string> {
+    /// Helper function to remove a generic prefix from a string
+    const removePrefix = (value: string, prefix: string) =>
+      value.startsWith(prefix) ? value.slice(prefix.length) : null;
 
-        try {
-            // First, try `effekt --version`:
-            const versionOutput = await this.execCommand(`"${path}" --version`);
+    try {
+      // First, try `effekt --version`:
+      const versionOutput = await this.execCommand(`"${path}" --version`);
 
-            const version = removePrefix(versionOutput.trim(), "Effekt "); // NOTE: the space is important here
-            if (!version) {
-                throw new Error(`Output of '${path} --version' is not in the correct format 'Effekt 0.1.2'; got '${versionOutput}' instead.`);
-            }
-            return version;
-        } catch (versionError) {
-            // Otherwise try `effekt --help`:
-            try {
-                const helpOutput = await this.execCommand(`"${path}" --help`);
+      const version = removePrefix(versionOutput.trim(), 'Effekt '); // NOTE: the space is important here
+      if (!version) {
+        throw new Error(
+          `Output of '${path} --version' is not in the correct format 'Effekt 0.1.2'; got '${versionOutput}' instead.`
+        );
+      }
+      return version;
+    } catch (versionError) {
+      // Otherwise try `effekt --help`:
+      try {
+        const helpOutput = await this.execCommand(`"${path}" --help`);
 
-                // Check if the output contains the word "Effekt" anywhere
-                if (/\bEffekt\b/i.test(helpOutput)) {
-                    return "0.2.2"; // XXX: Hardcoded, 0.2.2 is the last version of Effekt without `--version`.
-                }
-            } catch (helpError) {
-                // If both `--version` and `--help` fail, throw an error
-                throw new Error(`Failed to determine Effekt version: ${versionError}\nHelp command also failed: ${helpError}`);
-            }
+        // Check if the output contains the word "Effekt" anywhere
+        if (/\bEffekt\b/i.test(helpOutput)) {
+          return '0.2.2'; // XXX: Hardcoded, 0.2.2 is the last version of Effekt without `--version`.
         }
-
-        // If we reach this point, it means --help succeeded but didn't contain "Effekt"
-        throw new Error("Unable to determine Effekt version");
+      } catch (helpError) {
+        // If both `--version` and `--help` fail, throw an error
+        throw new Error(
+          `Failed to determine Effekt version: ${versionError}\nHelp command also failed: ${helpError}`
+        );
+      }
     }
 
-    public async getEffektVersion(): Promise<string> {
-        if (!this.effektVersion) {
-            const effektPath = await this.locateEffektExecutable();
-            const currentVersion = await this.fetchEffektVersion(effektPath.path);
-            this.effektVersion = currentVersion;
+    // If we reach this point, it means --help succeeded but didn't contain "Effekt"
+    throw new Error('Unable to determine Effekt version');
+  }
+
+  public async getEffektVersion(): Promise<string> {
+    if (!this.effektVersion) {
+      const effektPath = await this.locateEffektExecutable();
+      const currentVersion = await this.fetchEffektVersion(effektPath.path);
+      this.effektVersion = currentVersion;
+    }
+    return this.effektVersion || '';
+  }
+
+  /**
+   * Executes a shell command and returns the output.
+   * @param command The command to execute.
+   * @param resolveWithStderr If true, the promise is resolved with combined stdout and stderr.
+   * @returns A promise that resolves with the command output.
+   */
+  private async execCommand(
+    command: string,
+    resolveWithStderr?: boolean
+  ): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      cp.exec(
+        command,
+        { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(error);
+          } else {
+            const output =
+              stdout.trim() + (resolveWithStderr ? stderr.trim() : '');
+            resolve(output);
+          }
         }
-        return this.effektVersion || '';
-    }
+      );
+    });
+  }
 
-    /**
-     * Executes a shell command and returns the output.
-     * @param command The command to execute.
-     * @param resolveWithStderr If true, the promise is resolved with combined stdout and stderr.
-     * @returns A promise that resolves with the command output.
-     */
-    private async execCommand(command: string, resolveWithStderr?: boolean): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            cp.exec(command, { encoding: 'utf8', maxBuffer: 1024 * 1024 }, (error, stdout, stderr) => {
-                if (error) {
-                    reject(error);
-                } else {
-                    const output = stdout.trim() + (resolveWithStderr ? stderr.trim() : '');
-                    resolve(output);
-                }
-            });
-        });
-    }
+  /**
+   * Logs a message to the output channel.
+   * @param level The log level ('INFO' or 'ERROR').
+   * @param message The message to log.
+   */
+  private logMessage(level: 'INFO' | 'ERROR', message: string) {
+    this.outputChannel.appendLine(
+      `[${new Date().toISOString()}] ${level}: ${message}`
+    );
+  }
 
-    /**
-     * Logs a message to the output channel.
-     * @param level The log level ('INFO' or 'ERROR').
-     * @param message The message to log.
-     */
-    private logMessage(level: 'INFO' | 'ERROR', message: string) {
-        this.outputChannel.appendLine(`[${new Date().toISOString()}] ${level}: ${message}`);
-    }
-
-    /**
-     * Fetches the latest version of a package from npm.
-     * @param packageName The name of the npm package.
-     * @returns A promise that resolves with the latest version string.
-     */
-    private async getLatestNPMVersion(packageName: string): Promise<string> {
-        return new Promise<string>((resolve, reject) => {
-            const url = new URL(`https://registry.npmjs.org/${packageName}/latest`);
-            https.get(url, (res) => {
-                let data = '';
-                res.on('data', (chunk) => data += chunk);
-                res.on('end', () => {
-                    try {
-                        const json = JSON.parse(data);
-                        resolve(json.version);
-                    } catch (error) {
-                        reject(new Error(`Failed to parse npm registry response: ${error}`));
-                    }
-                });
-            }).on('error', (error) => {
-                reject(new Error(`Failed to fetch latest version from npm: ${error}`));
-            });
-        });
-    }
-
-    /**
-     * Locates the Effekt executable: tries to look into user given path first, then tries 'possibleEffektExecutables' in PATH.
-     */
-    public async locateEffektExecutable(): Promise<EffektExecutableInfo> {
-        const customEffektPath = this.config.get<string>("executable");
-        if (customEffektPath) {
+  /**
+   * Fetches the latest version of a package from npm.
+   * @param packageName The name of the npm package.
+   * @returns A promise that resolves with the latest version string.
+   */
+  private async getLatestNPMVersion(packageName: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      const url = new URL(`https://registry.npmjs.org/${packageName}/latest`);
+      https
+        .get(url, (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => {
             try {
-                const version = await this.fetchEffektVersion(customEffektPath);
-                this.logMessage('INFO', `Located executable at custom path ${customEffektPath} with version ${version}`);
-                return { path: customEffektPath, version };
+              const json = JSON.parse(data);
+              resolve(json.version);
             } catch (error) {
-                this.showErrorWithLogs(`Custom Effekt executable not working: ${customEffektPath}. ${error}`);
+              reject(
+                new Error(`Failed to parse npm registry response: ${error}`)
+              );
             }
-        }
-
-        for (const effektPath of this.possibleEffektExecutables) {
-            try {
-                const version = await this.fetchEffektVersion(effektPath);
-                this.logMessage('INFO', `Located executable at path ${effektPath} with version ${version}`);
-                return { path: effektPath, version };
-            } catch {
-                // Try next option
-            }
-        }
-
-        throw new EffektExecutableNotFoundError('Effekt executable not found');
-    }
-
-    /**
-     * Installs or updates Effekt.
-     * @param action The action being performed ('install' or 'update').
-     * @returns A promise that resolves with the installed/updated version or an empty string.
-     */
-    private async installOrUpdateEffekt(action: 'install' | 'update', client?: EffektLanguageClient): Promise<string> {
-        if (!(await this.checkJava())) {
-            this.logMessage('INFO', 'Java is not installed.');
-            return '';
-        }
-        if (!(await this.checkNodeAndNpm())) {
-            this.logMessage('INFO', 'Node / npm are not installed.');
-            return '';
-        }
-
-        return vscode.window.withProgress({
-            location: vscode.ProgressLocation.Notification,
-            title: `${action === 'update' ? 'Updating' : 'Installing'} Effekt`,
-            cancellable: false
-        }, async (progress) => {
-            try {
-                // The client is optional as when installing Effekt, there is no LSP initialized yet
-                await client?.stop();
-                progress.report({ increment: 0, message: 'Preparing...' });
-                await this.runNpmInstall();
-                progress.report({ increment: 50, message: 'Verifying installation...' });
-
-                const verificationResult = await this.verifyEffektInstallation();
-                progress.report({ increment: 100, message: 'Completed' });
-
-                this.handleInstallationResult(verificationResult, action);
-
-                await client?.start();
-                return verificationResult.success ? verificationResult.version || '' : '';
-            } catch (error) {
-                this.showErrorWithLogs(`Failed to ${action} Effekt: ${error}`);
-                this.updateStatusBar();
-
-                await client?.start();
-                return '';
-            }
+          });
+        })
+        .on('error', (error) => {
+          reject(
+            new Error(`Failed to fetch latest version from npm: ${error}`)
+          );
         });
+    });
+  }
+
+  /**
+   * Locates the Effekt executable: tries to look into user given path first, then tries 'possibleEffektExecutables' in PATH.
+   */
+  public async locateEffektExecutable(): Promise<EffektExecutableInfo> {
+    const customEffektPath = this.config.get<string>('executable');
+    if (customEffektPath) {
+      try {
+        const version = await this.fetchEffektVersion(customEffektPath);
+        this.logMessage(
+          'INFO',
+          `Located executable at custom path ${customEffektPath} with version ${version}`
+        );
+        return { path: customEffektPath, version };
+      } catch (error) {
+        this.showErrorWithLogs(
+          `Custom Effekt executable not working: ${customEffektPath}. ${error}`
+        );
+      }
     }
 
-    private async runNpmInstall(): Promise<void> {
-        // 1) Check if the npm root is managed by Nix in order to produce a better error
-        const npmRoot = await this.execCommand('npm root -g');
-        if (npmRoot.startsWith("/nix/store")) {
-            this.logMessage('ERROR', 'NPM root is in the read-only Nix store. Installation is not possible.');
-            throw new Error('Detected Nix environment: NPM global modules are stored in a read-only directory managed by Nix. Installation cannot proceed.');
-        }
-
-        // 2) Actually run `npm install -g ...`
-        const npmInstallCommand = `npm install -g ${this.effektNPMPackage}@latest`;
-        const npmOutput = await this.execCommand(npmInstallCommand);
-
-        this.logMessage('INFO', `Ran '${npmInstallCommand}'; stdout: ${npmOutput}`);
+    for (const effektPath of this.possibleEffektExecutables) {
+      try {
+        const version = await this.fetchEffektVersion(effektPath);
+        this.logMessage(
+          'INFO',
+          `Located executable at path ${effektPath} with version ${version}`
+        );
+        return { path: effektPath, version };
+      } catch {
+        // Try next option
+      }
     }
 
-    private async verifyEffektInstallation(): Promise<InstallationResult> {
+    throw new EffektExecutableNotFoundError('Effekt executable not found');
+  }
+
+  /**
+   * Installs or updates Effekt.
+   * @param action The action being performed ('install' or 'update').
+   * @returns A promise that resolves with the installed/updated version or an empty string.
+   */
+  private async installOrUpdateEffekt(
+    action: 'install' | 'update',
+    client?: EffektLanguageClient
+  ): Promise<string> {
+    if (!(await this.checkJava())) {
+      this.logMessage('INFO', 'Java is not installed.');
+      return '';
+    }
+    if (!(await this.checkNodeAndNpm())) {
+      this.logMessage('INFO', 'Node / npm are not installed.');
+      return '';
+    }
+
+    return vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: `${action === 'update' ? 'Updating' : 'Installing'} Effekt`,
+        cancellable: false
+      },
+      async (progress) => {
         try {
-            const { path: execPath, version } = await this.locateEffektExecutable();
+          // The client is optional as when installing Effekt, there is no LSP initialized yet
+          await client?.stop();
+          progress.report({ increment: 0, message: 'Preparing...' });
+          await this.runNpmInstall();
+          progress.report({
+            increment: 50,
+            message: 'Verifying installation...'
+          });
+
+          const verificationResult = await this.verifyEffektInstallation();
+          progress.report({ increment: 100, message: 'Completed' });
+
+          this.handleInstallationResult(verificationResult, action);
+
+          await client?.start();
+          return verificationResult.success
+            ? verificationResult.version || ''
+            : '';
+        } catch (error) {
+          this.showErrorWithLogs(`Failed to ${action} Effekt: ${error}`);
+          this.updateStatusBar();
+
+          await client?.start();
+          return '';
+        }
+      }
+    );
+  }
+
+  private async runNpmInstall(): Promise<void> {
+    // 1) Check if the npm root is managed by Nix in order to produce a better error
+    const npmRoot = await this.execCommand('npm root -g');
+    if (npmRoot.startsWith('/nix/store')) {
+      this.logMessage(
+        'ERROR',
+        'NPM root is in the read-only Nix store. Installation is not possible.'
+      );
+      throw new Error(
+        'Detected Nix environment: NPM global modules are stored in a read-only directory managed by Nix. Installation cannot proceed.'
+      );
+    }
+
+    // 2) Actually run `npm install -g ...`
+    const npmInstallCommand = `npm install -g ${this.effektNPMPackage}@latest`;
+    const npmOutput = await this.execCommand(npmInstallCommand);
+
+    this.logMessage('INFO', `Ran '${npmInstallCommand}'; stdout: ${npmOutput}`);
+  }
+
+  private async verifyEffektInstallation(): Promise<InstallationResult> {
+    try {
+      const { path: execPath, version } = await this.locateEffektExecutable();
+      return {
+        success: true,
+        executable: execPath,
+        message: `Effekt found successfully in ${execPath}.`,
+        version
+      };
+    } catch {
+      // If locateEffektExecutable fails, try to locate in global npm directory
+      const npmRoot = await this.execCommand('npm root -g');
+
+      for (const execName of this.possibleEffektExecutables) {
+        const fullPath = path.join(npmRoot, execName);
+        if (await this.fileExists(fullPath)) {
+          try {
+            const version = await this.fetchEffektVersion(fullPath);
             return {
-                success: true,
-                executable: execPath,
-                message: `Effekt found successfully in ${execPath}.`,
-                version
+              success: true,
+              executable: fullPath,
+              message: `Effekt found at ${fullPath}, but not in PATH.`,
+              version
             };
-        } catch (error) {
-            // If locateEffektExecutable fails, try to locate in global npm directory
-            const npmRoot = await this.execCommand('npm root -g');
-
-            for (const execName of this.possibleEffektExecutables) {
-                const fullPath = path.join(npmRoot, execName);
-                if (await this.fileExists(fullPath)) {
-                    try {
-                        const version = await this.fetchEffektVersion(fullPath);
-                        return {
-                            success: true,
-                            executable: fullPath,
-                            message: `Effekt found at ${fullPath}, but not in PATH.`,
-                            version
-                        };
-                    } catch {
-                        // Executable exists but doesn't work, continue to next
-                    }
-                }
-            }
-
-            return {
-                success: false,
-                message: "Effekt was installed but couldn't be located or executed. Please check your installation."
-            };
+          } catch {
+            // Executable exists but doesn't work, continue to next
+          }
         }
-    }
+      }
 
-    private async fileExists(filePath: string): Promise<boolean> {
-        try {
-            await fs.access(filePath);
-            return true;
-        } catch {
-            return false;
+      return {
+        success: false,
+        message:
+          "Effekt was installed but couldn't be located or executed. Please check your installation."
+      };
+    }
+  }
+
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async handleInstallationResult(
+    result: InstallationResult,
+    action: 'install' | 'update'
+  ): Promise<void> {
+    if (result.success && result.version) {
+      const baseMessage = `Effekt has been ${action === 'update' ? 'updated' : 'installed'} to version ${result.version}.`;
+
+      if (result.executable && !result.executable.includes(path.sep)) {
+        // Effekt is in PATH
+        const isUpdate = action === 'update';
+
+        const options = isUpdate
+          ? ['View Release Notes', 'Close']
+          : ['View Language Introduction', 'Close'];
+        const changelogResponse = await vscode.window.showInformationMessage(
+          baseMessage,
+          ...options
+        );
+
+        if (changelogResponse === 'View Release Notes') {
+          const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${result.version}`;
+          vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
+        } else if (changelogResponse === 'View Language Introduction') {
+          const introUrl = 'https://effekt-lang.org/docs/introduction';
+          vscode.env.openExternal(vscode.Uri.parse(introUrl));
         }
+      } else {
+        // Effekt is not in PATH
+        const fullMessage = `${baseMessage}\n${result.message}\nConsider adding it to your PATH for easier access.`;
+        vscode.window
+          .showWarningMessage(fullMessage, 'View Logs')
+          .then((selection) => {
+            if (selection === 'View Logs') {
+              this.outputChannel.show();
+            }
+          });
+        this.logMessage('INFO', fullMessage);
+      }
+      this.effektVersion = result.version;
+    } else {
+      this.showErrorWithLogs(result.message);
     }
 
-    private async handleInstallationResult(result: InstallationResult, action: 'install' | 'update'): Promise<void> {
-        if (result.success && result.version) {
-            const baseMessage = `Effekt has been ${action === 'update' ? 'updated' : 'installed'} to version ${result.version}.`;
+    this.updateStatusBar();
+  }
 
-            if (result.executable && !result.executable.includes(path.sep)) {
-                // Effekt is in PATH
-                const isUpdate = action === 'update';
+  /**
+   * Checks for Effekt updates and offers to install/update if necessary.
+   * @returns A promise that resolves with the current Effekt version.
+   */
+  public async checkForUpdatesAndInstall(
+    client?: EffektLanguageClient
+  ): Promise<string> {
+    try {
+      const currentVersion = await this.getEffektVersion();
+      const latestVersion = await this.getLatestNPMVersion(
+        this.effektNPMPackage
+      );
 
-                const options = isUpdate ? ['View Release Notes', 'Close'] : ['View Language Introduction', 'Close'];
-                const changelogResponse = await vscode.window.showInformationMessage(baseMessage, ...options);
+      // check if the latest version strictly newer than the current version
+      if (
+        !currentVersion ||
+        compareVersion(latestVersion, currentVersion, '>')
+      ) {
+        return this.promptForAction(latestVersion, 'update', client);
+      } else {
+        vscode.window.showInformationMessage(
+          `Effekt is up-to-date (version ${currentVersion}).`
+        );
+      }
 
-                if (changelogResponse === 'View Release Notes') {
-                    const changelogUrl = `https://github.com/effekt-lang/effekt/releases/tag/v${result.version}`;
-                    vscode.env.openExternal(vscode.Uri.parse(changelogUrl));
-                } else if (changelogResponse === 'View Language Introduction') {
-                    const introUrl = 'https://effekt-lang.org/docs/introduction';
-                    vscode.env.openExternal(vscode.Uri.parse(introUrl));
-                }
+      this.updateStatusBar();
+      return this.effektVersion || '';
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes('Effekt executable not found')
+      ) {
+        const latestVersion = await this.getLatestNPMVersion(
+          this.effektNPMPackage
+        );
+        return this.promptForAction(latestVersion, 'install', client);
+      } else {
+        this.showErrorWithLogs(`Failed to check Effekt: ${error}`);
+        return '';
+      }
+    }
+  }
 
-            } else {
-                // Effekt is not in PATH
-                const fullMessage = `${baseMessage}\n${result.message}\nConsider adding it to your PATH for easier access.`;
-                vscode.window.showWarningMessage(fullMessage, 'View Logs')
-                    .then(selection => {
-                        if (selection === 'View Logs') {
-                            this.outputChannel.show();
-                        }
-                    });
-                this.logMessage('INFO', fullMessage);
-            }
-            this.effektVersion = result.version;
-        } else {
-            this.showErrorWithLogs(result.message);
+  /**
+   * Prompts the user to perform an action (install or update) and executes it if confirmed.
+   * @param version The version to install or update to.
+   * @param action The action to perform ('install' or 'update').
+   * @returns A promise that resolves with the installed/updated version or an empty string.
+   */
+  private async promptForAction(
+    version: string,
+    action: 'install' | 'update',
+    client?: EffektLanguageClient
+  ): Promise<string> {
+    const message =
+      action === 'update'
+        ? `A new version of Effekt is available (${version}). Would you like to update?`
+        : `Effekt ${version} is available. Would you like to install it?`;
+
+    const response = await vscode.window.showInformationMessage(
+      message,
+      'Yes',
+      'No'
+    );
+    if (response === 'Yes') {
+      return this.installOrUpdateEffekt(action, client);
+    }
+    this.updateStatusBar();
+    return this.effektVersion || '';
+  }
+
+  /**
+   * Checks if Node.js and npm are installed and meet the minimum version requirements.
+   * @returns A promise that resolves with a boolean indicating if the requirements are met.
+   */
+  private async checkNodeAndNpm(): Promise<boolean> {
+    try {
+      const nodeVersion = await this.execCommand('node --version');
+      await this.execCommand('npm --version'); // Note: if needed, we could also check npm version.
+
+      const minNodeVersion = 'v16.0.0'; // Minimum supported Node.js version
+
+      if (compareVersion(nodeVersion, minNodeVersion, '<')) {
+        this.showErrorWithLogs(
+          `Node.js version ${minNodeVersion} or higher is required. You have ${nodeVersion}.`
+        );
+        return false;
+      }
+
+      this.logMessage('INFO', `Found Node.js version ${nodeVersion}`);
+
+      return true;
+    } catch {
+      this.showErrorWithLogs(
+        'Node.js and npm are required to install Effekt automatically. ' +
+          'Please install Node.js (which includes npm), then restart VSCode.'
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Checks if Java is installed and meets the minimum version requirement.
+   * @returns A promise that resolves with a boolean indicating if the requirements are met.
+   */
+  private async checkJava(): Promise<boolean> {
+    try {
+      const javaVersion = await this.getJavaVersion();
+      const minJavaVersion = '11.0.0'; // Minimum supported Java version
+
+      if (compareVersion(javaVersion, minJavaVersion, '<')) {
+        this.showErrorWithLogs(
+          `Java version ${minJavaVersion} or higher is required. You have ${javaVersion}.`
+        );
+        return false;
+      }
+
+      this.logMessage('INFO', `Found Java version ${javaVersion}`);
+
+      return true;
+    } catch (error) {
+      this.logMessage('ERROR', `When checking Java version got: ${error}`);
+
+      this.showErrorWithLogs(
+        'Java (JRE) is required to run Effekt. ' +
+          'Please install Java, then restart VSCode.'
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Extracts the Java version from the output of 'java -version' command.
+   * @returns A promise that resolves with the Java version string.
+   */
+  private async getJavaVersion(): Promise<string> {
+    try {
+      const output = await this.execCommand('java -version', true);
+
+      this.logMessage('INFO', `Got ${output} from 'java -version'`);
+
+      // Regular expressions to match different Java version formats
+      const versionRegexes = [
+        /version "((\d+\.\d+\.\d+).*?)"/, // Standard format: "11.0.2" or "1.8.0_292"
+        /version "((\d+).*?)"/, // OpenJDK format on some systems: "11" or "11-internal"
+        /(\d+\.\d+\.\d+)/ // Fallback for version without quotes
+      ];
+
+      let version = '';
+      for (const regex of versionRegexes) {
+        const match = output.match(regex);
+        if (match) {
+          version = match[2] || match[1]; // Prefer the version number without extra info
+          break;
         }
+      }
 
-        this.updateStatusBar();
+      if (!version) {
+        throw new Error('Unable to extract Java version from output');
+      }
+
+      // Handle special cases like "1.8.0_292" for Java 8
+      if (version.startsWith('1.')) {
+        version = version.split('.')[1];
+      }
+
+      // Remove any additional info after the version number
+      version = version.split('-')[0].split('_')[0];
+
+      return version;
+    } catch (error) {
+      throw new Error(`Failed to execute 'java -version': ${error}`);
     }
+  }
 
-    /**
-     * Checks for Effekt updates and offers to install/update if necessary.
-     * @returns A promise that resolves with the current Effekt version.
-     */
-    public async checkForUpdatesAndInstall(client?: EffektLanguageClient): Promise<string> {
-        try {
-            let currentVersion = await this.getEffektVersion();
-            const latestVersion = await this.getLatestNPMVersion(this.effektNPMPackage);
-
-            // check if the latest version strictly newer than the current version
-            if (!currentVersion || compareVersion(latestVersion, currentVersion, '>')) {
-                return this.promptForAction(latestVersion, 'update', client);
-            } else {
-                vscode.window.showInformationMessage(`Effekt is up-to-date (version ${currentVersion}).`);
-            }
-
-            this.updateStatusBar();
-            return this.effektVersion || '';
-        } catch (error) {
-            if (error instanceof Error && error.message.includes('Effekt executable not found')) {
-                const latestVersion = await this.getLatestNPMVersion(this.effektNPMPackage);
-                return this.promptForAction(latestVersion, 'install', client);
-            } else {
-                this.showErrorWithLogs(`Failed to check Effekt: ${error}`);
-                return '';
-            }
+  /**
+   * Shows an error message with an option to view logs.
+   * @param message The error message to show.
+   */
+  private showErrorWithLogs(message: string) {
+    const trimmedMessage = this.trimErrorMessage(message);
+    this.logMessage('ERROR', message); // Log the full message
+    vscode.window
+      .showErrorMessage(trimmedMessage, 'View Logs')
+      .then((selection) => {
+        if (selection === 'View Logs') {
+          this.outputChannel.show();
         }
+      });
+  }
+
+  /**
+   * Trims an error message to a reasonable length.
+   * @param message The message to trim.
+   * @returns The trimmed message.
+   */
+  private trimErrorMessage(message: string): string {
+    const maxLength = 160;
+    if (message.length <= maxLength) {
+      return message;
+    }
+    return message.substring(0, maxLength) + '... (see logs for full message)';
+  }
+
+  /**
+   * Updates the server status.
+   * @param status The new server status.
+   */
+  public updateServerStatus(
+    status: 'starting' | 'running' | 'stopped' | 'error'
+  ) {
+    this.serverStatus = status;
+    this.updateStatusBar();
+  }
+
+  /**
+   * Updates the status bar item based on the current server status.
+   */
+  private updateStatusBar() {
+    const statusConfig = {
+      starting: {
+        icon: '$(loading~spin) ',
+        tooltip: 'Effekt server is starting...',
+        color: undefined,
+        bgColor: undefined
+      },
+      running: {
+        icon: '$(check) ',
+        tooltip: 'Effekt server is running.',
+        color: undefined,
+        bgColor: undefined
+      },
+      stopped: {
+        icon: '$(stop-circle) ',
+        tooltip: 'Effekt server is stopped.',
+        color: 'statusBarItem.warningForeground',
+        bgColor: 'statusBarItem.warningBackground'
+      },
+      error: {
+        icon: '$(error) ',
+        tooltip: 'Effekt server encountered an error.',
+        color: 'statusBarItem.errorForeground',
+        bgColor: 'statusBarItem.errorBackground'
+      }
+    };
+
+    const config = statusConfig[this.serverStatus];
+    this.statusBarItem.text = `Ξ Effekt ${config.icon}`;
+    this.statusBarItem.tooltip = new vscode.MarkdownString(
+      `${config.tooltip}\n\n` +
+        `_Click to check for updates_\n\n` +
+        `---\n` +
+        `**Effekt Information:**\n` +
+        `- Version: ${this.effektVersion || '<unknown>'}\n` +
+        `- Status: ${this.serverStatus}\n` +
+        `- Backend: ${this.config.get<string>('backend') || '<unknown>'}`
+    );
+    this.statusBarItem.tooltip.isTrusted = true;
+
+    this.statusBarItem.color = config.color
+      ? new vscode.ThemeColor(config.color)
+      : undefined;
+    this.statusBarItem.backgroundColor = config.bgColor
+      ? new vscode.ThemeColor(config.bgColor)
+      : undefined;
+    this.statusBarItem.show();
+  }
+
+  /**
+   * Gets the command arguments for starting Effekt.
+   * @returns An array of command arguments.
+   */
+  public getEffektArgs(): string[] {
+    const args: string[] = [];
+    const effektBackend = this.config.get<string>('backend');
+    const effektLib = this.config.get<string>('lib');
+
+    if (effektBackend) {
+      args.push('--backend', effektBackend);
+    }
+    if (effektLib) {
+      args.push('--lib', effektLib);
     }
 
-    /**
-     * Prompts the user to perform an action (install or update) and executes it if confirmed.
-     * @param version The version to install or update to.
-     * @param action The action to perform ('install' or 'update').
-     * @returns A promise that resolves with the installed/updated version or an empty string.
-     */
-    private async promptForAction(version: string, action: 'install' | 'update', client?: EffektLanguageClient): Promise<string> {
-        const message = action === 'update'
-            ? `A new version of Effekt is available (${version}). Would you like to update?`
-            : `Effekt ${version} is available. Would you like to install it?`;
+    const folders = vscode.workspace.workspaceFolders || [];
+    // We deliberately use folder.uri.path rather than folder.uri.fsPath
+    // While the effekt binary is able to handle either, Git Bash on Windows
+    // cannot handle backslashes in paths.
+    // Using folder.uri.path rather than folder.uri.fsPath means that Effekt tasks
+    // works in PowerShell, cmd.exe and Git Bash.
+    folders.forEach((folder) => args.push('--includes', folder.uri.path));
 
-        const response = await vscode.window.showInformationMessage(message, 'Yes', 'No');
-        if (response === 'Yes') {
-            return this.installOrUpdateEffekt(action, client);
-        }
-        this.updateStatusBar();
-        return this.effektVersion || '';
-    }
-
-    /**
-     * Checks if Node.js and npm are installed and meet the minimum version requirements.
-     * @returns A promise that resolves with a boolean indicating if the requirements are met.
-     */
-    private async checkNodeAndNpm(): Promise<boolean> {
-        try {
-            const nodeVersion = await this.execCommand('node --version');
-            await this.execCommand('npm --version'); // Note: if needed, we could also check npm version.
-
-            const minNodeVersion = 'v16.0.0'; // Minimum supported Node.js version
-
-            if (compareVersion(nodeVersion, minNodeVersion, '<')) {
-                this.showErrorWithLogs(`Node.js version ${minNodeVersion} or higher is required. You have ${nodeVersion}.`);
-                return false;
-            }
-
-            this.logMessage("INFO", `Found Node.js version ${nodeVersion}`);
-
-            return true;
-        } catch (error) {
-            this.showErrorWithLogs(
-                "Node.js and npm are required to install Effekt automatically. " +
-                "Please install Node.js (which includes npm), then restart VSCode."
-            );
-            return false;
-        }
-    }
-
-    /**
-     * Checks if Java is installed and meets the minimum version requirement.
-     * @returns A promise that resolves with a boolean indicating if the requirements are met.
-     */
-    private async checkJava(): Promise<boolean> {
-        try {
-            const javaVersion = await this.getJavaVersion();
-            const minJavaVersion = '11.0.0'; // Minimum supported Java version
-
-            if (compareVersion(javaVersion, minJavaVersion, '<')) {
-                this.showErrorWithLogs(`Java version ${minJavaVersion} or higher is required. You have ${javaVersion}.`);
-                return false;
-            }
-
-            this.logMessage("INFO", `Found Java version ${javaVersion}`);
-
-            return true;
-        } catch (error) {
-            this.logMessage("ERROR", `When checking Java version got: ${error}`);
-
-            this.showErrorWithLogs(
-                "Java (JRE) is required to run Effekt. " +
-                "Please install Java, then restart VSCode."
-            );
-            return false;
-        }
-    }
-
-    /**
-     * Extracts the Java version from the output of 'java -version' command.
-     * @returns A promise that resolves with the Java version string.
-     */
-    private async getJavaVersion(): Promise<string> {
-        try {
-            const output = await this.execCommand('java -version', true);
-
-            this.logMessage('INFO', `Got ${output} from 'java -version'`);
-
-            // Regular expressions to match different Java version formats
-            const versionRegexes = [
-                /version "((\d+\.\d+\.\d+).*?)"/, // Standard format: "11.0.2" or "1.8.0_292"
-                /version "((\d+).*?)"/, // OpenJDK format on some systems: "11" or "11-internal"
-                /(\d+\.\d+\.\d+)/,  // Fallback for version without quotes
-            ];
-
-            let version = '';
-            for (const regex of versionRegexes) {
-                const match = output.match(regex);
-                if (match) {
-                    version = match[2] || match[1]; // Prefer the version number without extra info
-                    break;
-                }
-            }
-
-            if (!version) {
-                throw new Error('Unable to extract Java version from output');
-            }
-
-            // Handle special cases like "1.8.0_292" for Java 8
-            if (version.startsWith('1.')) {
-                version = version.split('.')[1];
-            }
-
-            // Remove any additional info after the version number
-            version = version.split('-')[0].split('_')[0];
-
-            return version;
-        } catch (error) {
-            throw new Error(`Failed to execute 'java -version': ${error}`);
-        }
-    }
-
-    /**
-     * Shows an error message with an option to view logs.
-     * @param message The error message to show.
-     */
-    private showErrorWithLogs(message: string) {
-        const trimmedMessage = this.trimErrorMessage(message);
-        this.logMessage('ERROR', message);  // Log the full message
-        vscode.window.showErrorMessage(trimmedMessage, 'View Logs')
-            .then(selection => {
-                if (selection === 'View Logs') {
-                    this.outputChannel.show();
-                }
-            });
-    }
-
-    /**
-     * Trims an error message to a reasonable length.
-     * @param message The message to trim.
-     * @returns The trimmed message.
-     */
-    private trimErrorMessage(message: string): string {
-        const maxLength = 160;
-        if (message.length <= maxLength) return message;
-        return message.substring(0, maxLength) + '... (see logs for full message)';
-    }
-
-    /**
-     * Updates the server status.
-     * @param status The new server status.
-     */
-    public updateServerStatus(status: 'starting' | 'running' | 'stopped' | 'error') {
-        this.serverStatus = status;
-        this.updateStatusBar();
-    }
-
-    /**
-     * Updates the status bar item based on the current server status.
-     */
-    private updateStatusBar() {
-        const statusConfig = {
-            'starting': { icon: "$(loading~spin) ", tooltip: "Effekt server is starting...", color: undefined, bgColor: undefined },
-            'running': { icon: "$(check) ", tooltip: "Effekt server is running.", color: undefined, bgColor: undefined },
-            'stopped': { icon: "$(stop-circle) ", tooltip: "Effekt server is stopped.", color: "statusBarItem.warningForeground", bgColor: "statusBarItem.warningBackground" },
-            'error': { icon: "$(error) ", tooltip: "Effekt server encountered an error.", color: "statusBarItem.errorForeground", bgColor: "statusBarItem.errorBackground" }
-        };
-
-        const config = statusConfig[this.serverStatus];
-        this.statusBarItem.text = `Ξ Effekt ${config.icon}`;
-        this.statusBarItem.tooltip = new vscode.MarkdownString(`${config.tooltip}\n\n`
-            + `_Click to check for updates_\n\n`
-            + `---\n`
-            + `**Effekt Information:**\n`
-            + `- Version: ${this.effektVersion || '<unknown>'}\n`
-            + `- Status: ${this.serverStatus}\n`
-            + `- Backend: ${this.config.get<string>("backend") || '<unknown>'}`);
-        this.statusBarItem.tooltip.isTrusted = true;
-
-        this.statusBarItem.color = config.color ? new vscode.ThemeColor(config.color) : undefined;
-        this.statusBarItem.backgroundColor = config.bgColor ? new vscode.ThemeColor(config.bgColor) : undefined;
-        this.statusBarItem.show();
-    }
-
-    /**
-     * Gets the command arguments for starting Effekt.
-     * @returns An array of command arguments.
-     */
-    public getEffektArgs(): string[] {
-        const args: string[] = [];
-        const effektBackend = this.config.get<string>("backend");
-        const effektLib = this.config.get<string>("lib");
-
-        if (effektBackend) args.push("--backend", effektBackend);
-        if (effektLib) args.push("--lib", effektLib);
-
-        const folders = vscode.workspace.workspaceFolders || [];
-        // We deliberately use folder.uri.path rather than folder.uri.fsPath
-        // While the effekt binary is able to handle either, Git Bash on Windows
-        // cannot handle backslashes in paths.
-        // Using folder.uri.path rather than folder.uri.fsPath means that Effekt tasks
-        // works in PowerShell, cmd.exe and Git Bash.
-        folders.forEach(folder => args.push("--includes", folder.uri.path));
-
-        return args;
-    }
+    return args;
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import {
   LanguageClientOptions,
   ServerOptions,
   StreamInfo,
-  State as ClientState
+  State as ClientState,
 } from 'vscode-languageclient/node';
 import { EffektManager, EffektExecutableNotFoundError } from './effektManager';
 import { EffektIRContentProvider } from './irProvider';
@@ -19,7 +19,7 @@ const outputChannel = vscode.window.createOutputChannel('Effekt Extension');
 
 function logMessage(level: 'INFO' | 'ERROR', message: string) {
   outputChannel.appendLine(
-    `[${new Date().toISOString()}] ${level}: ${message}`
+    `[${new Date().toISOString()}] ${level}: ${message}`,
   );
 }
 
@@ -34,7 +34,7 @@ function registerCommands(context: vscode.ExtensionContext) {
         client.start();
       }
     }),
-    vscode.commands.registerCommand('effekt.runFile', runEffektFile)
+    vscode.commands.registerCommand('effekt.runFile', runEffektFile),
   );
 }
 
@@ -60,12 +60,12 @@ async function runEffektFile(uri: vscode.Uri) {
     presentation: {
       reveal: vscode.TaskRevealKind.Always,
       panel: vscode.TaskPanelKind.Dedicated,
-      clear: true
-    }
+      clear: true,
+    },
   };
 
   const execution = new vscode.ShellExecution(effektExecutable.path, args, {
-    cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+    cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
   });
 
   const task = new vscode.Task(
@@ -74,7 +74,7 @@ async function runEffektFile(uri: vscode.Uri) {
     'Run Effekt File',
     'Effekt',
     execution,
-    []
+    [],
   );
 
   await vscode.tasks.executeTask(task);
@@ -95,8 +95,8 @@ class EffektRunCodeLensProvider implements vscode.CodeLensProvider {
         new vscode.CodeLens(range, {
           title: '$(play) Run',
           command: 'effekt.runFile',
-          arguments: [document.uri]
-        })
+          arguments: [document.uri],
+        }),
       );
     }
 
@@ -122,7 +122,7 @@ export async function activate(context: vscode.ExtensionContext) {
       // Handle unexpected errors
       console.error('An unexpected error occurred:', error);
       vscode.window.showErrorMessage(
-        'An unexpected error occurred. Check the logs for details.'
+        'An unexpected error occurred. Check the logs for details.',
       );
     }
   }
@@ -146,7 +146,7 @@ async function handleEffektUpdates() {
     await effektManager.checkForUpdatesAndInstall(client);
   if (!installedEffektVersion) {
     vscode.window.showWarningMessage(
-      'Effekt is not installed. LSP features may not work correctly.'
+      'Effekt is not installed. LSP features may not work correctly.',
     );
   } else {
     logMessage('INFO', 'Using the existing version of Effekt');
@@ -163,7 +163,7 @@ async function startEffektLanguageServer(context: vscode.ExtensionContext) {
       const socket = net.connect({ port: 5007 });
       const result: StreamInfo = {
         writer: socket,
-        reader: socket
+        reader: socket,
       };
       return Promise.resolve(result);
     };
@@ -182,7 +182,7 @@ async function startEffektLanguageServer(context: vscode.ExtensionContext) {
 
     serverOptions = {
       run: { command: effektExecutable.path, args, options: execOptions },
-      debug: { command: effektExecutable.path, args, options: execOptions }
+      debug: { command: effektExecutable.path, args, options: execOptions },
     };
   }
 
@@ -190,20 +190,20 @@ async function startEffektLanguageServer(context: vscode.ExtensionContext) {
     initializationOptions: vscode.workspace.getConfiguration('effekt'),
     documentSelector: [
       { scheme: 'file', language: 'effekt' },
-      { scheme: 'file', language: 'literate effekt' }
+      { scheme: 'file', language: 'literate effekt' },
     ],
     diagnosticCollectionName: 'effekt',
     synchronize: {
       // Send configuration updates to the language server
-      configurationSection: 'effekt'
-    }
+      configurationSection: 'effekt',
+    },
   };
 
   client = new EffektLanguageClient(
     'effektLanguageServer',
     'Effekt Language Server',
     serverOptions,
-    clientOptions
+    clientOptions,
   );
 
   client.onDidChangeState((event) => {
@@ -224,12 +224,12 @@ function registerCodeLensProviders(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.languages.registerCodeLensProvider(
       { language: 'effekt', scheme: 'file' },
-      new EffektRunCodeLensProvider()
+      new EffektRunCodeLensProvider(),
     ),
     vscode.languages.registerCodeLensProvider(
       { language: 'literate effekt', scheme: 'file' },
-      new EffektRunCodeLensProvider()
-    )
+      new EffektRunCodeLensProvider(),
+    ),
   );
 }
 
@@ -238,8 +238,8 @@ function registerIRProvider(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider(
       'effekt-ir',
-      effektIRContentProvider
-    )
+      effektIRContentProvider,
+    ),
   );
 
   client.onNotification(
@@ -252,22 +252,22 @@ function registerIRProvider(context: vscode.ExtensionContext) {
         vscode.window.showTextDocument(doc, {
           viewColumn: vscode.ViewColumn.Beside,
           preview: false,
-          preserveFocus: true
+          preserveFocus: true,
         });
       });
-    }
+    },
   );
 }
 
 function registerInlayProvider() {
   vscode.languages.registerInlayHintsProvider(
     { scheme: 'file', language: 'effekt' },
-    new InlayHintProvider(client)
+    new InlayHintProvider(client),
   );
 
   vscode.languages.registerInlayHintsProvider(
     { scheme: 'file', language: 'literate effekt' },
-    new InlayHintProvider(client)
+    new InlayHintProvider(client),
   );
 }
 // Decorate holes
@@ -278,7 +278,7 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
     opacity: '0.5',
     borderRadius: '4pt',
     light: { backgroundColor: 'rgba(0,0,0,0.05)' },
-    dark: { backgroundColor: 'rgba(255,255,255,0.05)' }
+    dark: { backgroundColor: 'rgba(255,255,255,0.05)' },
   });
 
   // based on https://github.com/microsoft/vscode-extension-samples/blob/master/decorator-sample/src/extension.ts
@@ -326,7 +326,7 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
       scheduleDecorations();
     },
     null,
-    context.subscriptions
+    context.subscriptions,
   );
 
   vscode.workspace.onDidChangeTextDocument(
@@ -336,7 +336,7 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
       }
     },
     null,
-    context.subscriptions
+    context.subscriptions,
   );
 
   scheduleDecorations();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,10 @@
 
 import * as vscode from 'vscode';
 import {
-    LanguageClientOptions,
-    ServerOptions,
-    StreamInfo,
-    State as ClientState
+  LanguageClientOptions,
+  ServerOptions,
+  StreamInfo,
+  State as ClientState
 } from 'vscode-languageclient/node';
 import { EffektManager, EffektExecutableNotFoundError } from './effektManager';
 import { EffektIRContentProvider } from './irProvider';
@@ -13,319 +13,339 @@ import { InlayHintProvider } from './inlayHintsProvider';
 import { EffektLanguageClient } from './effektLanguageClient';
 import * as net from 'net';
 
-
-
 let client: EffektLanguageClient;
 let effektManager: EffektManager;
-let outputChannel = vscode.window.createOutputChannel("Effekt Extension")
+const outputChannel = vscode.window.createOutputChannel('Effekt Extension');
 
 function logMessage(level: 'INFO' | 'ERROR', message: string) {
-    outputChannel.appendLine(`[${new Date().toISOString()}] ${level}: ${message}`);
+  outputChannel.appendLine(
+    `[${new Date().toISOString()}] ${level}: ${message}`
+  );
 }
 
 function registerCommands(context: vscode.ExtensionContext) {
-    context.subscriptions.push(
-        vscode.commands.registerCommand('effekt.checkForUpdates', async () => {
-            await effektManager?.checkForUpdatesAndInstall(client);
-        }),
-        vscode.commands.registerCommand('effekt.restartServer', async () => {
-            if (client) {
-                await client.stop();
-                client.start();
-            }
-        }),
-        vscode.commands.registerCommand('effekt.runFile', runEffektFile),
-    );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('effekt.checkForUpdates', async () => {
+      await effektManager?.checkForUpdatesAndInstall(client);
+    }),
+    vscode.commands.registerCommand('effekt.restartServer', async () => {
+      if (client) {
+        await client.stop();
+        client.start();
+      }
+    }),
+    vscode.commands.registerCommand('effekt.runFile', runEffektFile)
+  );
 }
 
 async function runEffektFile(uri: vscode.Uri) {
-    // Save the document if it has unsaved changes
-    const document = await vscode.workspace.openTextDocument(uri);
-    if (document.isDirty) {
-        await document.save();
+  // Save the document if it has unsaved changes
+  const document = await vscode.workspace.openTextDocument(uri);
+  if (document.isDirty) {
+    await document.save();
+  }
+
+  const effektExecutable = await effektManager.locateEffektExecutable();
+  // We deliberately use uri.path rather than uri.fsPath
+  // While the effekt binary is able to handle either, Git Bash on Windows
+  // cannot handle backslashes in paths.
+  // Using uri.path rather than uri.fsPath means that Effekt tasks
+  // works in PowerShell, cmd.exe and Git Bash.
+  const args = [uri.path, ...effektManager.getEffektArgs()];
+
+  const taskDefinition = {
+    type: 'shell',
+    command: effektExecutable.path,
+    args: args,
+    presentation: {
+      reveal: vscode.TaskRevealKind.Always,
+      panel: vscode.TaskPanelKind.Dedicated,
+      clear: true
     }
+  };
 
-    const effektExecutable = await effektManager.locateEffektExecutable();
-    // We deliberately use uri.path rather than uri.fsPath
-    // While the effekt binary is able to handle either, Git Bash on Windows
-    // cannot handle backslashes in paths.
-    // Using uri.path rather than uri.fsPath means that Effekt tasks
-    // works in PowerShell, cmd.exe and Git Bash.
-    const args = [uri.path, ...effektManager.getEffektArgs()];
+  const execution = new vscode.ShellExecution(effektExecutable.path, args, {
+    cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+  });
 
-    const taskDefinition = {
-        type: 'shell',
-        command: effektExecutable.path,
-        args: args,
-        presentation: {
-            reveal: vscode.TaskRevealKind.Always,
-            panel: vscode.TaskPanelKind.Dedicated,
-            clear: true
-        }
-    };
+  const task = new vscode.Task(
+    taskDefinition,
+    vscode.TaskScope.Workspace,
+    'Run Effekt File',
+    'Effekt',
+    execution,
+    []
+  );
 
-    const execution = new vscode.ShellExecution(
-        effektExecutable.path,
-        args,
-        { cwd: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath }
-    );
-
-    const task = new vscode.Task(
-        taskDefinition,
-        vscode.TaskScope.Workspace,
-        'Run Effekt File',
-        'Effekt',
-        execution,
-        []
-    );
-
-    await vscode.tasks.executeTask(task);
+  await vscode.tasks.executeTask(task);
 }
 
 class EffektRunCodeLensProvider implements vscode.CodeLensProvider {
-    public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
-        const codeLenses: vscode.CodeLens[] = [];
-        const text = document.getText();
-        const mainFunctionRegex = /^def\s+main\s*\(\s*\)/gm;
-        let match: RegExpExecArray | null;
+  public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
+    const codeLenses: vscode.CodeLens[] = [];
+    const text = document.getText();
+    const mainFunctionRegex = /^def\s+main\s*\(\s*\)/gm;
+    let match: RegExpExecArray | null;
 
-        while ((match = mainFunctionRegex.exec(text)) !== null) {
-            const line = document.lineAt(document.positionAt(match.index).line);
-            const range = new vscode.Range(line.range.start, line.range.end);
+    while ((match = mainFunctionRegex.exec(text)) !== null) {
+      const line = document.lineAt(document.positionAt(match.index).line);
+      const range = new vscode.Range(line.range.start, line.range.end);
 
-            codeLenses.push(new vscode.CodeLens(range, {
-                title: '$(play) Run',
-                command: 'effekt.runFile',
-                arguments: [document.uri]
-            }));
-        }
-
-        return codeLenses;
+      codeLenses.push(
+        new vscode.CodeLens(range, {
+          title: '$(play) Run',
+          command: 'effekt.runFile',
+          arguments: [document.uri]
+        })
+      );
     }
+
+    return codeLenses;
+  }
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-    effektManager = new EffektManager();
+  effektManager = new EffektManager();
 
-    try {
-        // If Effekt is installed (no matter which version), start the language server
-        await ensureEffektIsAvailable();
-        await initializeLSPAndProviders(context);
+  try {
+    // If Effekt is installed (no matter which version), start the language server
+    await ensureEffektIsAvailable();
+    await initializeLSPAndProviders(context);
 
-        await handleEffektUpdates();
-    } catch (error) {
-        if (error instanceof EffektExecutableNotFoundError) {
-            // If Effekt is not installed, we prompt the user to install it
-            await handleEffektUpdates();
-            await initializeLSPAndProviders(context);
-        } else {
-            // Handle unexpected errors
-            console.error("An unexpected error occurred:", error);
-            vscode.window.showErrorMessage('An unexpected error occurred. Check the logs for details.');
-        }
+    await handleEffektUpdates();
+  } catch (error) {
+    if (error instanceof EffektExecutableNotFoundError) {
+      // If Effekt is not installed, we prompt the user to install it
+      await handleEffektUpdates();
+      await initializeLSPAndProviders(context);
+    } else {
+      // Handle unexpected errors
+      console.error('An unexpected error occurred:', error);
+      vscode.window.showErrorMessage(
+        'An unexpected error occurred. Check the logs for details.'
+      );
     }
+  }
 }
 
 async function ensureEffektIsAvailable() {
-    await effektManager.locateEffektExecutable();
+  await effektManager.locateEffektExecutable();
 }
 
 async function initializeLSPAndProviders(context: vscode.ExtensionContext) {
-    await startEffektLanguageServer(context);
-    registerCommands(context);
-    registerCodeLensProviders(context);
-    registerIRProvider(context);
-    registerInlayProvider();
-    initializeHoleDecorations(context);
+  await startEffektLanguageServer(context);
+  registerCommands(context);
+  registerCodeLensProviders(context);
+  registerIRProvider(context);
+  registerInlayProvider();
+  initializeHoleDecorations(context);
 }
 
 async function handleEffektUpdates() {
-    const installedEffektVersion = await effektManager.checkForUpdatesAndInstall(client);
-    if (!installedEffektVersion) {
-        vscode.window.showWarningMessage(
-            'Effekt is not installed. LSP features may not work correctly.'
-        );
-    } else {
-        logMessage('INFO', "Using the existing version of Effekt");
-    }
+  const installedEffektVersion =
+    await effektManager.checkForUpdatesAndInstall(client);
+  if (!installedEffektVersion) {
+    vscode.window.showWarningMessage(
+      'Effekt is not installed. LSP features may not work correctly.'
+    );
+  } else {
+    logMessage('INFO', 'Using the existing version of Effekt');
+  }
 }
 
 async function startEffektLanguageServer(context: vscode.ExtensionContext) {
-    const config = vscode.workspace.getConfiguration("effekt");
-    let serverOptions: ServerOptions;
+  const config = vscode.workspace.getConfiguration('effekt');
+  let serverOptions: ServerOptions;
 
-    if (config.get<boolean>("debug")) {
-        serverOptions = () => {
-            // Connect to language server via socket
-            const socket = net.connect({ port: 5007 });
-            const result: StreamInfo = {
-                writer: socket,
-                reader: socket
-            };
-            return Promise.resolve(result);
-        };
-    } else {
-       
-        const effektExecutable = await effektManager.locateEffektExecutable();
-       
-        const args = ["--server", ...effektManager.getEffektArgs()];
-
-        /* > Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set.
-         * > If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors.
-         *
-         * https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
-         */
-        const isWindows = process.platform === 'win32';
-        const execOptions = { shell: isWindows };
-
-        serverOptions = {
-            run: { command: effektExecutable.path, args, options: execOptions },
-            debug: { command: effektExecutable.path, args, options: execOptions }
-        };
-    }
-
-    const clientOptions: LanguageClientOptions = {
-        initializationOptions: vscode.workspace.getConfiguration('effekt'),
-        documentSelector: [
-            { scheme: 'file', language: 'effekt' },
-            { scheme: 'file', language: 'literate effekt' }
-        ],
-        diagnosticCollectionName: "effekt",
-        synchronize: {
-            // Send configuration updates to the language server
-            configurationSection: 'effekt'
-        }
+  if (config.get<boolean>('debug')) {
+    serverOptions = () => {
+      // Connect to language server via socket
+      const socket = net.connect({ port: 5007 });
+      const result: StreamInfo = {
+        writer: socket,
+        reader: socket
+      };
+      return Promise.resolve(result);
     };
+  } else {
+    const effektExecutable = await effektManager.locateEffektExecutable();
 
-    client = new EffektLanguageClient(
-        'effektLanguageServer',
-        'Effekt Language Server',
-        serverOptions,
-        clientOptions
-    );
+    const args = ['--server', ...effektManager.getEffektArgs()];
 
-    client.onDidChangeState(event => {
-        if (event.newState === ClientState.Starting) {
-            effektManager.updateServerStatus('starting');
-        } else if (event.newState === ClientState.Running) {
-            effektManager.updateServerStatus('running');
-        } else if (event.newState === ClientState.Stopped) {
-            effektManager.updateServerStatus('stopped');
-        }
-    });
+    /* > Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set.
+     * > If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors.
+     *
+     * https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
+     */
+    const isWindows = process.platform === 'win32';
+    const execOptions = { shell: isWindows };
 
-    await client.start();
-    context.subscriptions.push(client);
+    serverOptions = {
+      run: { command: effektExecutable.path, args, options: execOptions },
+      debug: { command: effektExecutable.path, args, options: execOptions }
+    };
+  }
+
+  const clientOptions: LanguageClientOptions = {
+    initializationOptions: vscode.workspace.getConfiguration('effekt'),
+    documentSelector: [
+      { scheme: 'file', language: 'effekt' },
+      { scheme: 'file', language: 'literate effekt' }
+    ],
+    diagnosticCollectionName: 'effekt',
+    synchronize: {
+      // Send configuration updates to the language server
+      configurationSection: 'effekt'
+    }
+  };
+
+  client = new EffektLanguageClient(
+    'effektLanguageServer',
+    'Effekt Language Server',
+    serverOptions,
+    clientOptions
+  );
+
+  client.onDidChangeState((event) => {
+    if (event.newState === ClientState.Starting) {
+      effektManager.updateServerStatus('starting');
+    } else if (event.newState === ClientState.Running) {
+      effektManager.updateServerStatus('running');
+    } else if (event.newState === ClientState.Stopped) {
+      effektManager.updateServerStatus('stopped');
+    }
+  });
+
+  await client.start();
+  context.subscriptions.push(client);
 }
 
 function registerCodeLensProviders(context: vscode.ExtensionContext) {
-    context.subscriptions.push(
-        vscode.languages.registerCodeLensProvider(
-            { language: 'effekt', scheme: 'file' },
-            new EffektRunCodeLensProvider()
-        ),
-        vscode.languages.registerCodeLensProvider(
-            { language: 'literate effekt', scheme: 'file' },
-            new EffektRunCodeLensProvider()
-        )
-    );
+  context.subscriptions.push(
+    vscode.languages.registerCodeLensProvider(
+      { language: 'effekt', scheme: 'file' },
+      new EffektRunCodeLensProvider()
+    ),
+    vscode.languages.registerCodeLensProvider(
+      { language: 'literate effekt', scheme: 'file' },
+      new EffektRunCodeLensProvider()
+    )
+  );
 }
 
 function registerIRProvider(context: vscode.ExtensionContext) {
-    const effektIRContentProvider = new EffektIRContentProvider();
-    context.subscriptions.push(
-        vscode.workspace.registerTextDocumentContentProvider('effekt-ir', effektIRContentProvider)
-    );
+  const effektIRContentProvider = new EffektIRContentProvider();
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      'effekt-ir',
+      effektIRContentProvider
+    )
+  );
 
-    client.onNotification('$/effekt/publishIR', (params: { filename: string, content: string }) => {
-        const { filename, content } = params;
-        const uri = vscode.Uri.parse(`effekt-ir:${filename}`);
-        effektIRContentProvider.update(uri, content);
-        vscode.workspace.openTextDocument(uri).then(doc => {
-            vscode.window.showTextDocument(doc, {
-                viewColumn: vscode.ViewColumn.Beside,
-                preview: false,
-                preserveFocus: true
-            });
+  client.onNotification(
+    '$/effekt/publishIR',
+    (params: { filename: string; content: string }) => {
+      const { filename, content } = params;
+      const uri = vscode.Uri.parse(`effekt-ir:${filename}`);
+      effektIRContentProvider.update(uri, content);
+      vscode.workspace.openTextDocument(uri).then((doc) => {
+        vscode.window.showTextDocument(doc, {
+          viewColumn: vscode.ViewColumn.Beside,
+          preview: false,
+          preserveFocus: true
         });
-    });
+      });
+    }
+  );
 }
 
-function registerInlayProvider(){
-    vscode.languages.registerInlayHintsProvider(
-        { scheme: 'file', language: 'effekt' },
-        new InlayHintProvider(client)
-    );
+function registerInlayProvider() {
+  vscode.languages.registerInlayHintsProvider(
+    { scheme: 'file', language: 'effekt' },
+    new InlayHintProvider(client)
+  );
 
-    vscode.languages.registerInlayHintsProvider(
-        { scheme: 'file', language: 'literate effekt' },
-        new InlayHintProvider(client)
-    );
+  vscode.languages.registerInlayHintsProvider(
+    { scheme: 'file', language: 'literate effekt' },
+    new InlayHintProvider(client)
+  );
 }
-    // Decorate holes
-    // ---
-    // It would be nice if there was a way to reuse the scopes of the tmLanguage file
-    function initializeHoleDecorations(context: vscode.ExtensionContext) {
-    const holeDelimiterDecoration = vscode.window.createTextEditorDecorationType({
-        opacity: '0.5',
-        borderRadius: '4pt',
-        light: { backgroundColor: "rgba(0,0,0,0.05)" },
-        dark: { backgroundColor: "rgba(255,255,255,0.05)" }
-    });
+// Decorate holes
+// ---
+// It would be nice if there was a way to reuse the scopes of the tmLanguage file
+function initializeHoleDecorations(context: vscode.ExtensionContext) {
+  const holeDelimiterDecoration = vscode.window.createTextEditorDecorationType({
+    opacity: '0.5',
+    borderRadius: '4pt',
+    light: { backgroundColor: 'rgba(0,0,0,0.05)' },
+    dark: { backgroundColor: 'rgba(255,255,255,0.05)' }
+  });
 
-    // based on https://github.com/microsoft/vscode-extension-samples/blob/master/decorator-sample/src/extension.ts
-    let timeout: NodeJS.Timeout;
-    let editor = vscode.window.activeTextEditor;
+  // based on https://github.com/microsoft/vscode-extension-samples/blob/master/decorator-sample/src/extension.ts
+  let timeout: NodeJS.Timeout;
+  let editor = vscode.window.activeTextEditor;
 
-    function scheduleDecorations() {
-        if (timeout) { clearTimeout(timeout); }
-        timeout = setTimeout(updateHoles, 50);
+  function scheduleDecorations() {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(updateHoles, 50);
+  }
+
+  const holeRegex = /<>|<{|}>/g;
+  /**
+   * TODO clean this up -- ideally move it to the language server
+   */
+  function updateHoles() {
+    if (!editor) {
+      return;
     }
 
-    const holeRegex = /<>|<{|}>/g;
-    /**
-     * TODO clean this up -- ideally move it to the language server
-     */
-    function updateHoles() {
-        if (!editor) { return; }
+    const text = editor.document.getText();
+    const positionAt = editor.document.positionAt;
 
-        const text = editor.document.getText();
-        const positionAt = editor.document.positionAt;
+    const holeDelimiters: vscode.DecorationOptions[] = [];
+    let match;
 
-        let holeDelimiters: vscode.DecorationOptions[] = [];
-        let match;
-
-        function addDelimiter(from: number, to: number) {
-            const begin = positionAt(from);
-            const end = positionAt(to);
-            holeDelimiters.push({ range: new vscode.Range(begin, end) });
-        }
-
-        while (match = holeRegex.exec(text)) {
-            addDelimiter(match.index, match.index + 2);
-        }
-
-        editor.setDecorations(holeDelimiterDecoration, holeDelimiters);
+    function addDelimiter(from: number, to: number) {
+      const begin = positionAt(from);
+      const end = positionAt(to);
+      holeDelimiters.push({ range: new vscode.Range(begin, end) });
     }
 
-    vscode.window.onDidChangeActiveTextEditor(ed => {
-        editor = ed;
+    while ((match = holeRegex.exec(text))) {
+      addDelimiter(match.index, match.index + 2);
+    }
+
+    editor.setDecorations(holeDelimiterDecoration, holeDelimiters);
+  }
+
+  vscode.window.onDidChangeActiveTextEditor(
+    (ed) => {
+      editor = ed;
+      scheduleDecorations();
+    },
+    null,
+    context.subscriptions
+  );
+
+  vscode.workspace.onDidChangeTextDocument(
+    (event) => {
+      if (editor && event.document === editor.document) {
         scheduleDecorations();
-    }, null, context.subscriptions);
+      }
+    },
+    null,
+    context.subscriptions
+  );
 
-    vscode.workspace.onDidChangeTextDocument(event => {
-        if (editor && event.document === editor.document) {
-            scheduleDecorations();
-        }
-    }, null, context.subscriptions);
-
-    scheduleDecorations();
+  scheduleDecorations();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-    if (!client) {
-        return undefined;
-    }
-    effektManager.updateServerStatus('stopped');
-    return client.stop();
+  if (!client) {
+    return undefined;
+  }
+  effektManager.updateServerStatus('stopped');
+  return client.stop();
 }

--- a/src/inlayHintsProvider.ts
+++ b/src/inlayHintsProvider.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
-import { Code2ProtocolConverter, LanguageClient, Protocol2CodeConverter } from 'vscode-languageclient/node';
+import {
+  Code2ProtocolConverter,
+  LanguageClient,
+  Protocol2CodeConverter
+} from 'vscode-languageclient/node';
 import {
   InlayHintRequest,
   InlayHintParams,
@@ -9,7 +13,7 @@ import {
 export class InlayHintProvider implements vscode.InlayHintsProvider {
   private client: LanguageClient;
   private protocol2code: Protocol2CodeConverter;
-  private code2protocol : Code2ProtocolConverter;
+  private code2protocol: Code2ProtocolConverter;
 
   constructor(client: LanguageClient) {
     this.client = client;
@@ -46,7 +50,7 @@ export class InlayHintProvider implements vscode.InlayHintsProvider {
       return [];
     }
 
-    const filtered = response.filter(h => {
+    const filtered = response.filter((h) => {
       return !(h.data === 'capture' && !showCaptureHints);
     });
 

--- a/src/inlayHintsProvider.ts
+++ b/src/inlayHintsProvider.ts
@@ -2,12 +2,12 @@ import * as vscode from 'vscode';
 import {
   Code2ProtocolConverter,
   LanguageClient,
-  Protocol2CodeConverter
+  Protocol2CodeConverter,
 } from 'vscode-languageclient/node';
 import {
   InlayHintRequest,
   InlayHintParams,
-  InlayHint as LspInlayHint
+  InlayHint as LspInlayHint,
 } from 'vscode-languageserver-protocol';
 
 export class InlayHintProvider implements vscode.InlayHintsProvider {
@@ -24,7 +24,7 @@ export class InlayHintProvider implements vscode.InlayHintsProvider {
   async provideInlayHints(
     document: vscode.TextDocument,
     range: vscode.Range,
-    _token: vscode.CancellationToken
+    _token: vscode.CancellationToken,
   ): Promise<vscode.InlayHint[]> {
     const config = vscode.workspace.getConfiguration('effekt');
     const showCaptureHints = config.get<boolean>('inlayHints.captures', true);
@@ -38,12 +38,12 @@ export class InlayHintProvider implements vscode.InlayHintsProvider {
 
     const params: InlayHintParams = {
       textDocument: this.code2protocol.asTextDocumentIdentifier(document),
-      range: this.code2protocol.asRange(range)
+      range: this.code2protocol.asRange(range),
     };
 
     const response = (await this.client.sendRequest(
       InlayHintRequest.type,
-      params
+      params,
     )) as LspInlayHint[] | null | undefined;
 
     if (!response) {

--- a/src/irProvider.ts
+++ b/src/irProvider.ts
@@ -1,17 +1,19 @@
 import * as vscode from 'vscode';
 
-export class EffektIRContentProvider implements vscode.TextDocumentContentProvider {
-    private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
-    onDidChange?: vscode.Event<vscode.Uri> = this._onDidChange.event;
+export class EffektIRContentProvider
+  implements vscode.TextDocumentContentProvider
+{
+  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange?: vscode.Event<vscode.Uri> = this._onDidChange.event;
 
-    private contents: Map<string, string> = new Map();
+  private contents = new Map<string, string>();
 
-    update(uri: vscode.Uri, content: string) {
-        this.contents.set(uri.toString(), content);
-        this._onDidChange.fire(uri);
-    }
+  update(uri: vscode.Uri, content: string) {
+    this.contents.set(uri.toString(), content);
+    this._onDidChange.fire(uri);
+  }
 
-    provideTextDocumentContent(uri: vscode.Uri): string {
-        return this.contents.get(uri.toString()) || '';
-    }
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    return this.contents.get(uri.toString()) || '';
+  }
 }


### PR DESCRIPTION
This PR introduces 
- ESLint as a linter (`npx eslint .`  or  `npm run lint `  and `npm run lint:fix`  to lint or lint&fix all files at once)
- Prettier as a formatter (`npm run format` and `npm run format:check`) 


The CI performs `npm run lint` and `npm run format:check`
resolves #73 