### PR TITLE
Allow running indented 'main'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ class EffektRunCodeLensProvider implements vscode.CodeLensProvider {
   public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
     const codeLenses: vscode.CodeLens[] = [];
     const text = document.getText();
-    const mainFunctionRegex = /(?<=^|\s)def\s+main\s*\(\s*\)/gm;
+    const mainFunctionRegex = /^[^\S\r\n]*def\s+main\s*\(\s*\)/gm;
     let match: RegExpExecArray | null;
 
     while ((match = mainFunctionRegex.exec(text)) !== null) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ class EffektRunCodeLensProvider implements vscode.CodeLensProvider {
   public provideCodeLenses(document: vscode.TextDocument): vscode.CodeLens[] {
     const codeLenses: vscode.CodeLens[] = [];
     const text = document.getText();
-    const mainFunctionRegex = /^def\s+main\s*\(\s*\)/gm;
+    const mainFunctionRegex = /(?<=^|\s)def\s+main\s*\(\s*\)/gm;
     let match: RegExpExecArray | null;
 
     while ((match = mainFunctionRegex.exec(text)) !== null) {


### PR DESCRIPTION
Screenshot:
<img width="254" alt="Screenshot 2025-05-16 at 15 45 46" src="https://github.com/user-attachments/assets/48cb1b57-b629-4dbf-90f6-84dc92df4af6" />

Before, the `def main()` in `examples` would _not_ have a `|> Run` button because of the indentation, but we have programs that look like this, so I do want to support it :)

---

Motivation extracted from #12:

> The regex for finding `main` could be tweaked: it's also fine to show the `|> Run` button for:
> ```scala
> def myFunction(): Int = 42
> 
> namespace examples { 
>   def main() = println(myFunction())
> }
> ```
> which is currently not shown, since the regex doesn't account for leading whitespace:
> 
> https://github.com/effekt-lang/effekt-vscode/blob/07b504c52fbdb5560b40ebc48e181944fdb17aa1/src/extension.ts#L82