### PR TITLE
Handle failure to communicate with npm gracefully

### DIFF
--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -417,7 +417,7 @@ export class EffektManager {
           error.message.includes('Failed to fetch latest version from npm')
         ) {
           this.logMessage(
-            "ERROR",
+            'ERROR',
             `Fetching current version from npm failed: ${error.message}`,
           );
           vscode.window.showWarningMessage(

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -407,6 +407,7 @@ export class EffektManager {
           vscode.window.showErrorMessage(
             'Effekt is not installed and we could not connect to NPM. Please check your network connection and reload.',
           );
+          return '';
         }
       } else if (
         // check if the latest version strictly newer than the current version

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -415,7 +415,9 @@ export class EffektManager {
           error instanceof Error &&
           error.message.includes('Failed to fetch latest version from npm')
         ) {
-          console.log(`Fetching current version from npm failed: ${error.message}`);
+          console.log(
+            `Fetching current version from npm failed: ${error.message}`
+          );
           if (currentVersion) {
             vscode.window.showWarningMessage(
               'Could not retrieve current Effekt version, using locally installed Effekt.',
@@ -427,7 +429,9 @@ export class EffektManager {
             );
             return '';
           }
-        } else { throw error; } // rethrow
+        } else {
+          throw error; // rethrow
+        }
       }
     } catch (error) {
       if (

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -415,7 +415,8 @@ export class EffektManager {
           error instanceof Error &&
           error.message.includes('Failed to fetch latest version from npm')
         ) {
-          this.logMessage("ERROR",
+          this.logMessage(
+            "ERROR",
             `Fetching current version from npm failed: ${error.message}`,
           );
           if (currentVersion) {

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -416,7 +416,7 @@ export class EffektManager {
           error.message.includes('Failed to fetch latest version from npm')
         ) {
           console.log(
-            `Fetching current version from npm failed: ${error.message}`
+            `Fetching current version from npm failed: ${error.message}`,
           );
           if (currentVersion) {
             vscode.window.showWarningMessage(

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -393,23 +393,23 @@ export class EffektManager {
       const currentVersion = await this.getEffektVersion();
       const latestVersion = await this.getLatestNPMVersion(
         this.effektNPMPackage,
-      ).catch(function(err: string) {
+      ).catch(function (_err: string) {
         return null;
       });
 
-      if(latestVersion === null) {
+      if (latestVersion === null) {
         // requesting latest version from NPM failed
         if (currentVersion) {
           vscode.window.showWarningMessage(
-            "Could not retrieve current Effekt version, using locally installed Effekt."
+            'Could not retrieve current Effekt version, using locally installed Effekt.'
           );
         } else {
           vscode.window.showErrorMessage(
-            "Effekt is not installed and we could not connect to NPM. Please check your network connection and reload."
+            'Effekt is not installed and we could not connect to NPM. Please check your network connection and reload.'
           );
         }
       } else if (
-      // check if the latest version strictly newer than the current version
+        // check if the latest version strictly newer than the current version
         !currentVersion ||
         compareVersion(latestVersion, currentVersion, '>')
       ) {

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -401,11 +401,11 @@ export class EffektManager {
         // requesting latest version from NPM failed
         if (currentVersion) {
           vscode.window.showWarningMessage(
-            'Could not retrieve current Effekt version, using locally installed Effekt.'
+            'Could not retrieve current Effekt version, using locally installed Effekt.',
           );
         } else {
           vscode.window.showErrorMessage(
-            'Effekt is not installed and we could not connect to NPM. Please check your network connection and reload.'
+            'Effekt is not installed and we could not connect to NPM. Please check your network connection and reload.',
           );
         }
       } else if (

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -415,7 +415,7 @@ export class EffektManager {
           error instanceof Error &&
           error.message.includes('Failed to fetch latest version from npm')
         ) {
-          console.log(
+          this.logMessage("ERROR",
             `Fetching current version from npm failed: ${error.message}`,
           );
           if (currentVersion) {

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -393,10 +393,23 @@ export class EffektManager {
       const currentVersion = await this.getEffektVersion();
       const latestVersion = await this.getLatestNPMVersion(
         this.effektNPMPackage,
-      );
+      ).catch(function(err: string) {
+        return null;
+      });
 
+      if(latestVersion === null) {
+        // requesting latest version from NPM failed
+        if (currentVersion) {
+          vscode.window.showWarningMessage(
+            "Could not retrieve current Effekt version, using locally installed Effekt."
+          );
+        } else {
+          vscode.window.showErrorMessage(
+            "Effekt is not installed and we could not connect to NPM. Please check your network connection and reload."
+          );
+        }
+      } else if (
       // check if the latest version strictly newer than the current version
-      if (
         !currentVersion ||
         compareVersion(latestVersion, currentVersion, '>')
       ) {


### PR DESCRIPTION
Fixes #72 by printing a more useful message.

If Effekt can be found locally:
<img width="670" alt="Screenshot 2025-05-19 at 14 43 36" src="https://github.com/user-attachments/assets/d08899da-55a7-4a20-a6af-52203b5a2ba5" />

if it can't:
<img width="670" alt="Screenshot 2025-05-19 at 15 54 23" src="https://github.com/user-attachments/assets/ccd19958-8088-4334-818e-967492d431d9" />


