### PR TITLE
Focus holes on editor navigation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,6 @@ import * as net from 'net';
 let client: EffektLanguageClient;
 let effektManager: EffektManager;
 const outputChannel = vscode.window.createOutputChannel('Effekt Extension');
-const holeRegex = /<>|<{|}>/g;
 
 function logMessage(level: 'INFO' | 'ERROR', message: string) {
   outputChannel.appendLine(
@@ -129,6 +128,8 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   }
   vscode.window.onDidChangeTextEditorSelection((event) => {
+    const holeRegex = /<>|<{|}>/g;
+
     console.log('on did change');
     const editor = event.textEditor;
     const pos = editor.selection.active;
@@ -354,6 +355,7 @@ function initializeHoleDecorations(context: vscode.ExtensionContext) {
     timeout = setTimeout(updateHoles, 50);
   }
 
+  const holeRegex = /<>|<{|}>/g;
   /**
    * TODO clean this up -- ideally move it to the language server
    */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,20 +303,9 @@ function initializeHolesView(context: vscode.ExtensionContext) {
     }),
   );
   vscode.window.onDidChangeTextEditorSelection((event) => {
-    const holeRegex = /<>|<{|}>/g;
     const editor = event.textEditor;
     const pos = editor.selection.active;
-    const text = editor.document.getText();
-    let match;
-    while ((match = holeRegex.exec(text))) {
-      const from = editor.document.positionAt(match.index);
-      const to = editor.document.positionAt(match.index + 2); // the matched delimeter will be two characters long
-      const range = new vscode.Range(from, to);
-      if (range.contains(pos)) {
-        holesViewProvider.focusHoles(pos);
-        break;
-      }
-    }
+    holesViewProvider.focusHoles(pos);
   });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -281,6 +281,7 @@ function initializeHolesView(context: vscode.ExtensionContext) {
       const activeEditor = vscode.window.activeTextEditor;
       if (activeEditor && activeEditor.document.uri.toString() === params.uri) {
         holesViewProvider.updateHoles(params.holes);
+        holesViewProvider.focusHoles(activeEditor.selection.active);
       }
     },
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -273,7 +273,7 @@ function initializeHolesView(context: vscode.ExtensionContext) {
   const holesByUri = new Map<string, EffektHoleInfo[]>();
 
   client.onNotification(
-    '$/effekt/publishHoles', // FIXME, hole positions are 0-based (lsp), but we send 1-based information
+    '$/effekt/publishHoles',
     (params: { uri: string; holes: EffektHoleInfo[] }) => {
       holesByUri.set(params.uri, params.holes);
       const activeEditor = vscode.window.activeTextEditor;
@@ -310,10 +310,10 @@ function initializeHolesView(context: vscode.ExtensionContext) {
     let match;
     while ((match = holeRegex.exec(text))) {
       const from = editor.document.positionAt(match.index);
-      const to = editor.document.positionAt(match.index + 2);
+      const to = editor.document.positionAt(match.index + 2); // the matched delimeter will be two characters long
       const range = new vscode.Range(from, to);
       if (range.contains(pos)) {
-        console.log(holesViewProvider.focusHoles(pos));
+        holesViewProvider.focusHoles(pos);
         break;
       }
     }

--- a/src/holesPanel/effektHoleInfo.ts
+++ b/src/holesPanel/effektHoleInfo.ts
@@ -9,6 +9,7 @@ export interface EffektHoleInfo {
   importedTypes: TypeBinding[];
   terms: TermBinding[];
   types: TypeBinding[];
+  highlighted?: boolean;
 }
 
 export interface TermBinding {

--- a/src/holesPanel/effektHoleInfo.ts
+++ b/src/holesPanel/effektHoleInfo.ts
@@ -9,7 +9,6 @@ export interface EffektHoleInfo {
   importedTypes: TypeBinding[];
   terms: TermBinding[];
   types: TypeBinding[];
-  highlighted?: boolean;
 }
 
 export interface TermBinding {

--- a/src/holesPanel/holes.css
+++ b/src/holesPanel/holes.css
@@ -244,6 +244,7 @@ code {
   font-size: 1em;
 }
 .hole-card.highlighted {
-  border: 2px solid var(--vscode-editorSuggestWidget-highlightForeground, #007acc);
+  border: 2px solid
+    var(--vscode-editorSuggestWidget-highlightForeground, #007acc);
   background-color: rgba(0, 122, 204, 0.05);
 }

--- a/src/holesPanel/holes.css
+++ b/src/holesPanel/holes.css
@@ -243,3 +243,7 @@ code {
   margin-bottom: 1em;
   font-size: 1em;
 }
+.hole-card.highlighted {
+  border: 2px solid var(--vscode-editorSuggestWidget-highlightForeground, #007acc);
+  background-color: rgba(0, 122, 204, 0.05);
+}

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -46,11 +46,11 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
     this.webviewView.webview.html = generateWebView(holes, cssUri);
   }
 
-  public focusHoles(pos: vscode.Position): string | undefined {
+  public focusHoles(pos: vscode.Position) {
     const found = this.holes.find((hole) => {
       const start = hole.range.start;
       const end = hole.range.end;
-      // Compare line and character
+      // Check if the cursor position is within the hole
       const afterStart =
         pos.line > start.line ||
         (pos.line === start.line && pos.character >= start.character);
@@ -65,8 +65,6 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
         command: 'highlightHole',
         holeId: found.id,
       });
-      return found.id;
     }
-    return undefined;
   }
 }

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -5,6 +5,7 @@ import { EffektHoleInfo } from './effektHoleInfo';
 export class HolesViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'effekt.holesView';
   private webviewView?: vscode.WebviewView;
+  private holes: EffektHoleInfo[] = [];
 
   constructor(private readonly context: vscode.ExtensionContext) {}
 
@@ -42,5 +43,29 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
     );
 
     this.webviewView.webview.html = generateWebView(holes, cssUri);
+  }
+  public focusHoles(pos: vscode.Position): string | undefined {
+    const found = this.holes.find((hole) => {
+      const start = hole.range.start;
+      const end = hole.range.end;
+
+      // Compare line and character
+      const afterStart =
+        pos.line > start.line ||
+        (pos.line === start.line && pos.character >= start.character);
+      const beforeEnd =
+        pos.line < end.line ||
+        (pos.line === end.line && pos.character <= end.character);
+      return afterStart && beforeEnd;
+    });
+
+    if (found) {
+      const id = found.id;
+      if (this.webviewView) {
+        this.webviewView.webview.postMessage({ type: 'focusHole', id });
+      }
+      return id;
+    }
+    return undefined;
   }
 }

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -66,10 +66,10 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
     if (containing.length > 0) {
       found = containing.reduce((closest, curr) => {
         const currDist =
-          Math.abs(curr.range.start.line - pos.line) * 1000 +
+          Math.abs(curr.range.start.line - pos.line) +
           Math.abs(curr.range.start.character - pos.character);
         const closestDist =
-          Math.abs(closest.range.start.line - pos.line) * 1000 +
+          Math.abs(closest.range.start.line - pos.line) +
           Math.abs(closest.range.start.character - pos.character);
         return currDist < closestDist ? curr : closest;
       });

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -60,7 +60,11 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
       return afterStart && beforeEnd;
     });
 
-    if (found) {
+    if (found && this.webviewView) {
+      this.webviewView.webview.postMessage({
+        command: 'highlightHole',
+        holeId: found.id,
+      });
       return found.id;
     }
     return undefined;

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -30,6 +30,7 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
   }
 
   public updateHoles(holes: EffektHoleInfo[]) {
+    this.holes = holes;
     if (!this.webviewView) {
       return;
     }
@@ -44,11 +45,11 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
 
     this.webviewView.webview.html = generateWebView(holes, cssUri);
   }
+
   public focusHoles(pos: vscode.Position): string | undefined {
     const found = this.holes.find((hole) => {
       const start = hole.range.start;
       const end = hole.range.end;
-
       // Compare line and character
       const afterStart =
         pos.line > start.line ||
@@ -60,11 +61,7 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
     });
 
     if (found) {
-      const id = found.id;
-      if (this.webviewView) {
-        this.webviewView.webview.postMessage({ type: 'focusHole', id });
-      }
-      return id;
+      return found.id;
     }
     return undefined;
   }

--- a/src/holesPanel/holesViewProvider.ts
+++ b/src/holesPanel/holesViewProvider.ts
@@ -47,10 +47,11 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
   }
 
   public focusHoles(pos: vscode.Position) {
-    const found = this.holes.find((hole) => {
+    // Find all holes that contain the cursor position (to support nested holes)
+    const containing = this.holes.filter((hole) => {
       const start = hole.range.start;
       const end = hole.range.end;
-      // Check if the cursor position is within the hole
+
       const afterStart =
         pos.line > start.line ||
         (pos.line === start.line && pos.character >= start.character);
@@ -59,6 +60,20 @@ export class HolesViewProvider implements vscode.WebviewViewProvider {
         (pos.line === end.line && pos.character <= end.character);
       return afterStart && beforeEnd;
     });
+
+    // If multiple holes contain the cursor (nested), pick the one whose start is closest to the cursor
+    let found = undefined;
+    if (containing.length > 0) {
+      found = containing.reduce((closest, curr) => {
+        const currDist =
+          Math.abs(curr.range.start.line - pos.line) * 1000 +
+          Math.abs(curr.range.start.character - pos.character);
+        const closestDist =
+          Math.abs(closest.range.start.line - pos.line) * 1000 +
+          Math.abs(closest.range.start.character - pos.character);
+        return currDist < closestDist ? curr : closest;
+      });
+    }
 
     if (found && this.webviewView) {
       this.webviewView.webview.postMessage({

--- a/src/holesPanel/holesWebView.ts
+++ b/src/holesPanel/holesWebView.ts
@@ -104,7 +104,7 @@ function renderHolesList(holes: EffektHoleInfo[]): string {
  */
 function renderHoleCard(hole: EffektHoleInfo, idx: number): string {
   return /*html*/ `
-    <section class="hole-card">
+    <section class="hole-card" id="hole-${escapeHtml(hole.id)}">
       <div class="hole-header">
         <span class="hole-id">Hole: ${escapeHtml(hole.id)}</span>
         <span class="hole-range">[${hole.range.start.line + 1}:${hole.range.start.character + 1} - ${hole.range.end.line + 1}:${hole.range.end.character + 1}]</span>
@@ -196,6 +196,18 @@ function getClientScript(): string {
         const body = header.nextElementSibling;
         body.classList.toggle('hidden');
       }
+      window.addEventListener('message', event => {
+        const message = event.data;
+        if (message.command === 'highlightHole') {
+          const holeId = message.holeId;
+          const el = document.getElementById('hole-' + holeId);
+          if (el) {
+            document.querySelectorAll('.hole-card').forEach(e => e.classList.remove('highlighted'));
+            el.classList.add('highlighted');
+            el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
+        }
+      });
     </script>
   `;
 }

--- a/src/holesPanel/holesWebView.ts
+++ b/src/holesPanel/holesWebView.ts
@@ -1,56 +1,34 @@
 import * as vscode from 'vscode';
 import { EffektHoleInfo } from './effektHoleInfo';
 import { escapeHtml } from './htmlUtil';
+
+/**
+ * Generates the full HTML content for the Effekt Holes webview panel.
+ */
 export function generateWebView(
   holes: EffektHoleInfo[],
   cssUri: vscode.Uri,
 ): string {
-  // Helper for dropdown section
-  function renderExpDropdown({
-    title,
-    count,
-    idx,
-    kind,
-    placeholder,
-    itemsHtml,
-  }: {
-    title: string;
-    count: number;
-    idx: number;
-    kind: string;
-    placeholder: string;
-    itemsHtml: string;
-  }) {
-    return /*html*/ `
-      <div class="exp-dropdown-section">
-        <div class="exp-dropdown-header collapsed" onclick="toggleDropdown(this)">
-          <span class="exp-dropdown-toggle">&#9660;</span>
-          <span class="exp-dropdown-title">${escapeHtml(title)} (${count})</span>
-        </div>
-        <div class="exp-dropdown-body hidden" id="${kind}-dropdown-body-${idx}">
-          <input class="filter-box" placeholder="${escapeHtml(placeholder)}" oninput="filterDropdownList(event, '${kind}-dropdown-list-${idx}')" />
-          <div class="bindings-list exp-dropdown-list" id="${kind}-dropdown-list-${idx}">
-            ${itemsHtml}
-          </div>
-        </div>
-      </div>
-    `;
-  }
   const showHoles = vscode.workspace
     .getConfiguration('effekt')
     .get<boolean>('showHoles');
 
-  const holesPanelDesc = `
-    <div class="desc">
-      This panel shows information about the types and terms in scope for each typed hole.
-      Holes are placeholders for missing code used for type-driven development.
-      You can create a hole using the <code>&lt;&gt;</code> syntax.
-      For example, you can write a definition without a right-hand side as follows:
-      <pre>def foo() = &lt;&gt;</pre><br/>
-      Use <code>&lt;{ x }&gt;</code> in order to fill in a hole with a statement or expression <code>x</code>, for example:
-      <pre>def foo() = &lt;{ println("foo"); 42 }&gt;</pre>
-    </div>
-  `;
+  const content = !showHoles
+    ? renderHolesDisabledSection()
+    : holes.length === 0
+      ? renderNoHolesSection()
+      : renderHolesList(holes);
+
+  return renderFullHtmlDocument(cssUri, content);
+}
+
+/**
+ * Renders the full HTML document with head and body sections.
+ */
+function renderFullHtmlDocument(
+  cssUri: vscode.Uri,
+  bodyContent: string,
+): string {
   return /*html*/ `
     <!DOCTYPE html>
     <html lang="en">
@@ -63,119 +41,161 @@ export function generateWebView(
     <body>
       <div class="container">
         <h1>Effekt Holes</h1>
-     ${
-       !showHoles
-         ? /*html*/ `<div class="empty">
-        <div class="warning">
-          <b>Warning:</b> The Holes Panel requires the setting <b>Extension &gt; Effekt &gt; Show Holes</b> to be enabled to function.
-        </div>
-        ${holesPanelDesc}
-
-      </div>`
-         : holes.length === 0
-           ? /*html*/ `<div class="empty">
-          There are no holes in this file.
-          ${holesPanelDesc}
-
-        </div>`
-           : holes
-               .map(
-                 (hole, idx) => /*html*/ `
-          <section class="hole-card">
-            <div class="hole-header">
-              <span class="hole-id">Hole: ${escapeHtml(hole.id)}</span>
-              <span class="hole-range">[${hole.range.start.line + 1}:${hole.range.start.character + 1} - ${hole.range.end.line + 1}:${hole.range.end.character + 1}]</span>
-            </div>
-
-            <div class="expected-type-alert">
-              <div class="expected-type-alert-title">Expected Type</div>
-              <div class="expected-type-alert-desc">
-                ${hole.expectedType ? escapeHtml(hole.expectedType) : '<span class="empty">N/A</span>'}
-              </div>
-            </div>
-            <div class="hole-field indented-field">
-              <span class="field-label">Inner type:</span>
-              <span class="field-value">${hole.innerType ? `<code>${escapeHtml(hole.innerType)}</code>` : '<span class="empty">N/A</span>'}</span>
-            </div>
-
-            ${renderExpDropdown({
-              title: 'Terms',
-              count: hole.terms.length,
-              idx,
-              kind: 'terms',
-              placeholder: 'Search terms...',
-              itemsHtml:
-                hole.terms
-                  .map(
-                    (t) =>
-                      `<div class="binding"><span class="binding-term">${escapeHtml(t.name)}</span>: <span class="binding-type">${escapeHtml(t.type)}</span></div>`,
-                  )
-                  .join('') || '<span class="empty">None</span>',
-            })}
-            ${renderExpDropdown({
-              title: 'Types',
-              count: hole.types.length,
-              idx,
-              kind: 'types',
-              placeholder: 'Search types...',
-              itemsHtml:
-                hole.types
-                  .map(
-                    (t) =>
-                      `<div class="binding"><span class="binding-term">${escapeHtml(t.name)}</span>: <span class="binding-type">${escapeHtml(t.kind)}</span></div>`,
-                  )
-                  .join('') || '<span class="empty">None</span>',
-            })}
-            ${renderExpDropdown({
-              title: 'Imported Terms',
-              count: hole.importedTerms.length,
-              idx,
-              kind: 'imported-terms',
-              placeholder: 'Search imported terms...',
-              itemsHtml:
-                hole.importedTerms
-                  .map(
-                    (t) =>
-                      `<div class="binding"><span class="binding-term">${escapeHtml(t.name)}</span>: <span class="binding-type">${escapeHtml(t.type)}</span></div>`,
-                  )
-                  .join('') || '<span class="empty">None</span>',
-            })}
-            ${renderExpDropdown({
-              title: 'Imported Types',
-              count: hole.importedTypes.length,
-              idx,
-              kind: 'imported-types',
-              placeholder: 'Search imported types...',
-              itemsHtml:
-                hole.importedTypes
-                  .map(
-                    (t) =>
-                      `<div class="binding"><span class="binding-term">${escapeHtml(t.name)}</span>: <span class="binding-type">${escapeHtml(t.kind)}</span></div>`,
-                  )
-                  .join('') || '<span class="empty">None</span>',
-            })}
-          </section>
-        `,
-               )
-               .join('')
-     }
+        ${bodyContent}
       </div>
-      <script>
-        function filterDropdownList(event, listId) {
-          const filter = event.target.value.toLowerCase();
-          const items = document.querySelectorAll('#' + listId + ' .binding');
-          items.forEach(item => {
-            const text = item.textContent.toLowerCase();
-            item.style.display = text.includes(filter) ? '' : 'none';
-          });
-        }
-        function toggleDropdown(header) {
-          header.classList.toggle('collapsed');
-          const body = header.nextElementSibling;
-          body.classList.toggle('hidden');
-        }
-      </script>
+      ${getClientScript()}
     </body>
     </html>
+  `;
+}
+
+/**
+ * Renders the message shown when holes are disabled in the settings.
+ */
+function renderHolesDisabledSection(): string {
+  return /*html*/ `
+    <div class="empty">
+      <div class="warning">
+        <b>Warning:</b> The Holes Panel requires the setting <b>Extension &gt; Effekt &gt; Show Holes</b> to be enabled to function.
+      </div>
+      ${renderPanelDescription()}
+    </div>
+  `;
+}
+
+/**
+ * Renders the message shown when there are no holes in the file.
+ */
+function renderNoHolesSection(): string {
+  return /*html*/ `
+    <div class="empty">
+      There are no holes in this file.
+      ${renderPanelDescription()}
+    </div>
+  `;
+}
+
+/**
+ * Renders the descriptive text shown in both empty and warning states.
+ */
+function renderPanelDescription(): string {
+  return /*html*/ `
+    <div class="desc">
+      This panel shows information about the types and terms in scope for each typed hole.
+      Holes are placeholders for missing code used for type-driven development.
+      You can create a hole using the <code>&lt;&gt;</code> syntax.
+      For example, you can write a definition without a right-hand side as follows:
+      <pre>def foo() = &lt;&gt;</pre><br/>
+      Use <code>&lt;{ x }&gt;</code> in order to fill in a hole with a statement or expression <code>x</code>, for example:
+      <pre>def foo() = &lt;{ println("foo"); 42 }&gt;</pre>
+    </div>
+  `;
+}
+
+/**
+ * Renders the list of hole cards.
+ */
+function renderHolesList(holes: EffektHoleInfo[]): string {
+  return holes.map((hole, idx) => renderHoleCard(hole, idx)).join('');
+}
+
+/**
+ * Renders a single hole card with expected type, inner type, and scope dropdowns.
+ */
+function renderHoleCard(hole: EffektHoleInfo, idx: number): string {
+  return /*html*/ `
+    <section class="hole-card">
+      <div class="hole-header">
+        <span class="hole-id">Hole: ${escapeHtml(hole.id)}</span>
+        <span class="hole-range">[${hole.range.start.line + 1}:${hole.range.start.character + 1} - ${hole.range.end.line + 1}:${hole.range.end.character + 1}]</span>
+      </div>
+
+      <div class="expected-type-alert">
+        <div class="expected-type-alert-title">Expected Type</div>
+        <div class="expected-type-alert-desc">
+          ${hole.expectedType ? escapeHtml(hole.expectedType) : '<span class="empty">N/A</span>'}
+        </div>
+      </div>
+
+      <div class="hole-field indented-field">
+        <span class="field-label">Inner type:</span>
+        <span class="field-value">${hole.innerType ? `<code>${escapeHtml(hole.innerType)}</code>` : '<span class="empty">N/A</span>'}</span>
+      </div>
+
+      ${renderDropdownSection('Terms', hole.terms.length, idx, 'terms', 'Search terms...', renderBindingList(hole.terms, 'type'))}
+      ${renderDropdownSection('Types', hole.types.length, idx, 'types', 'Search types...', renderBindingList(hole.types, 'kind'))}
+      ${renderDropdownSection('Imported Terms', hole.importedTerms.length, idx, 'imported-terms', 'Search imported terms...', renderBindingList(hole.importedTerms, 'type'))}
+      ${renderDropdownSection('Imported Types', hole.importedTypes.length, idx, 'imported-types', 'Search imported types...', renderBindingList(hole.importedTypes, 'kind'))}
+    </section>
+  `;
+}
+
+/**
+ * Renders a dropdown section (terms/types/etc.) for a given hole.
+ */
+function renderDropdownSection(
+  title: string,
+  count: number,
+  idx: number,
+  kind: string,
+  placeholder: string,
+  itemsHtml: string,
+): string {
+  return /*html*/ `
+    <div class="exp-dropdown-section">
+      <div class="exp-dropdown-header collapsed" onclick="toggleDropdown(this)">
+        <span class="exp-dropdown-toggle">&#9660;</span>
+        <span class="exp-dropdown-title">${escapeHtml(title)} (${count})</span>
+      </div>
+      <div class="exp-dropdown-body hidden" id="${kind}-dropdown-body-${idx}">
+        <input class="filter-box" placeholder="${escapeHtml(placeholder)}" oninput="filterDropdownList(event, '${kind}-dropdown-list-${idx}')" />
+        <div class="bindings-list exp-dropdown-list" id="${kind}-dropdown-list-${idx}">
+          ${itemsHtml || '<span class="empty">None</span>'}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Renders the list of term/type bindings in a dropdown.
+ */
+function renderBindingList(
+  items: { name: string; type?: string; kind?: string }[],
+  key: 'type' | 'kind',
+): string {
+  return items
+    .map(
+      (item) => /*html*/ `
+      <div class="binding">
+        <span class="binding-term">${escapeHtml(item.name)}</span>: 
+        <span class="binding-type">${escapeHtml(item[key] ?? '')}</span>
+      </div>
+    `,
+    )
+    .join('');
+}
+
+/**
+ * Client-side JS for dropdown behavior and filtering.
+ */
+function getClientScript(): string {
+  return /*html*/ `
+    <script>
+      function filterDropdownList(event, listId) {
+        const filter = event.target.value.toLowerCase();
+        const items = document.querySelectorAll('#' + listId + ' .binding');
+        items.forEach(item => {
+          const text = item.textContent.toLowerCase();
+          item.style.display = text.includes(filter) ? '' : 'none';
+        });
+      }
+
+      function toggleDropdown(header) {
+        header.classList.toggle('collapsed');
+        const body = header.nextElementSibling;
+        body.classList.toggle('hidden');
+      }
+    </script>
   `;
 }


### PR DESCRIPTION
Allow focusing the hole at the cursor position (no hovering [ yet? ] ) for navigation between code and the holes panel.

[Screencast from 2025-06-04 13-20-06.webm](https://github.com/user-attachments/assets/0c63a142-6b35-4cf8-978f-f24112ba70d9)
