### PR TITLE
Fix colors in Holes panel

### DIFF
--- a/src/holesPanel/holes.css
+++ b/src/holesPanel/holes.css
@@ -22,8 +22,8 @@ body {
   --section-bg: var(--vscode-sideBar-background);
   --section-border: var(--vscode-editorWidget-border);
   --code-bg: var(--vscode-editorGutter-background);
-  --term: var(--vscode-terminal-ansiBlue);
-  --type: var(--vscode-terminal-ansiGreen);
+  --term: var(--vscode-editor-foreground);
+  --type: var(--vscode-editor-foreground);
   --highlight: var(--vscode-editor-selectionHighlightBackground);
   --muted: var(--vscode-editor-foreground);
 }
@@ -115,6 +115,7 @@ pre {
 
 .binding-term {
   color: var(--term);
+  font-weight: bold;
 }
 
 .binding-type {


### PR DESCRIPTION
Before, the `.css` used `... terminal-Ansi-Blue` and `... terminal-Ansi-Green` for terms and types in the panel, which looked off in some themes. This simple fix would change the term and type colors to be the foreground color of the current theme. This ensures readability while not hard coding colors. 