### PR TITLE
Run the language server directly with Java

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "trailingComma": "all",
   "singleQuote": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "endOfLine": "auto"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "dependencies": {
         "compare-versions": "^6.1.1",
         "esbuild-plugin-copy": "^2.1.1",
-        "vscode-languageclient": "^8.1.0"
+        "vscode-languageclient": "^8.1.0",
+        "which": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.25",
         "@types/vscode": "^1.80.0",
+        "@types/which": "^3.0.4",
         "@typescript-eslint/eslint-plugin": "^7.1.0",
         "@typescript-eslint/parser": "^7.1.0",
         "esbuild": "^0.25.4",
@@ -565,6 +567,12 @@
       "version": "1.92.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.92.0.tgz",
       "integrity": "sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==",
+      "dev": true
+    },
+    "node_modules/@types/which": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1156,6 +1164,21 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
       },
       "engines": {
         "node": ">= 8"
@@ -4599,18 +4622,17 @@
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "dependencies": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
       },
       "bin": {
-        "node-which": "bin/node-which"
+        "node-which": "bin/which.js"
       },
       "engines": {
-        "node": ">= 8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/which-boxed-primitive": {
@@ -4696,6 +4718,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/word-wrap": {
@@ -5060,6 +5090,12 @@
       "version": "1.92.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.92.0.tgz",
       "integrity": "sha512-DcZoCj17RXlzB4XJ7IfKdPTcTGDLYvTOcTNkvtjXWF+K2TlKzHHkBEXNWQRpBIXixNEUgx39cQeTFunY0E2msw==",
+      "dev": true
+    },
+    "@types/which": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
+      "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -5455,6 +5491,17 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "data-view-buffer": {
@@ -7847,12 +7894,18 @@
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "^3.1.1"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
+        }
       }
     },
     "which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show a panel with information about all typed holes in the program"
+        },
+        "effekt.javaExecutable": {
+          "type": "string",
+          "default": "java",
+          "markdownDescription": "Path to the Java executable used to run the Effekt LSP server. This is relevant if you have multiple Java versions installed and want to use a specific one."
         }
       }
     },
@@ -237,13 +242,15 @@
   "dependencies": {
     "compare-versions": "^6.1.1",
     "esbuild-plugin-copy": "^2.1.1",
-    "vscode-languageclient": "^8.1.0"
+    "vscode-languageclient": "^8.1.0",
+    "which": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.25",
     "@types/vscode": "^1.80.0",
+    "@types/which": "^3.0.4",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
     "@typescript-eslint/parser": "^7.1.0",
     "esbuild": "^0.25.4",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
         "effekt.javaExecutable": {
           "type": "string",
           "default": "java",
-          "markdownDescription": "Path to the Java executable used to run the Effekt LSP server. This is relevant if you have multiple Java versions installed and want to use a specific one."
+          "markdownDescription": "Path to the Java executable used to run the Effekt language server (e.g. `path/to/java` or `path\\to\\java.exe`). This is relevant if you have multiple Java versions installed and want to use a specific one."
         }
       }
     },

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -134,7 +134,11 @@ export class EffektManager {
       cp.execFile(
         command,
         args,
-        { encoding: 'utf8', maxBuffer: 1024 * 1024 },
+        // For Windows, it is important we use `shell: true` here.
+        // If not, running `execCommand('npm', ...)` doesn't work because the actual executable is called 'npm.cmd'.
+        // There may be other issues with EINVAL errors if `shell: true` is not set (see https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2).
+        // This also preserves the previous behaivor where we used `cp.exec` here.
+        { encoding: 'utf8', maxBuffer: 1024 * 1024, shell: true },
         (error, stdout, stderr) => {
           if (error) {
             reject(error);

--- a/src/effektManager.ts
+++ b/src/effektManager.ts
@@ -139,9 +139,9 @@ export class EffektManager {
           if (error) {
             reject(error);
           } else {
-            const out =
+            const output =
               stdout.trim() + (resolveWithStderr ? stderr.trim() : '');
-            resolve(out);
+            resolve(output);
           }
         },
       );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,9 +172,14 @@ async function startEffektLanguageServer(context: vscode.ExtensionContext) {
       return Promise.resolve(result);
     };
   } else {
-    const effektExecutable = await effektManager.locateEffektExecutable();
-
-    const args = ['--server', ...effektManager.getEffektArgs()];
+    const effektJAR = await effektManager.locateEffektJAR();
+    const javaExecutable = config.get<string>('javaExecutable') || 'java';
+    const args = [
+      '-jar',
+      effektJAR,
+      '--server',
+      ...effektManager.getEffektArgs(),
+    ];
 
     /* > Node.js will now error with EINVAL if a .bat or .cmd file is passed to child_process.spawn and child_process.spawnSync without the shell option set.
      * > If the input to spawn/spawnSync is sanitized, users can now pass { shell: true } as an option to prevent the occurrence of EINVALs errors.
@@ -185,8 +190,8 @@ async function startEffektLanguageServer(context: vscode.ExtensionContext) {
     const execOptions = { shell: isWindows };
 
     serverOptions = {
-      run: { command: effektExecutable.path, args, options: execOptions },
-      debug: { command: effektExecutable.path, args, options: execOptions },
+      run: { command: javaExecutable, args, options: execOptions },
+      debug: { command: javaExecutable, args, options: execOptions },
     };
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     /* Strict Type-Checking Option */
     "strict": true,
     /* Additional Checks */
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    /* Allow importing ES modules */
+    "esModuleInterop": true,
   },
   "exclude": ["node_modules", ".vscode-test"]
 }


### PR DESCRIPTION
The motivation for this is twofold:

1. The shell wrappers installed via npm seem to be broken on Windows (see #30).
2. Some users have multiple Java installations, so we would like to make the Java executable configurable. Since there are many ways to install Java on the various platforms (some can switch the JDK to use with `JAVA_HOME`, some can't), the only reliable way we found so far was to allow directly specifying the `java`/`java.exe` executable.

