### PR TITLE
Use prefix search

### DIFF
--- a/src/holesPanel/webview/BindingsSection.tsx
+++ b/src/holesPanel/webview/BindingsSection.tsx
@@ -64,6 +64,7 @@ export const BindingsSection: React.FC<BindingsSectionProps> = ({
     const searchResults = miniSearch.search(filter, {
       combineWith: 'OR',
       fuzzy: 0.2,
+      prefix: true,
     });
 
     return searchResults.map((result) => allBindings[result.id]);


### PR DESCRIPTION
In addition to fuzzy search, this PR enables prefix search in `MiniSearch`. This means that typing `pri` will show `println`. Previously, it would not, because the edit distance to `println` was to large (which is configured with the `fuzzy` parameter.