### PR TITLE
Use signature field on BindingInfo

### DIFF
--- a/src/holesPanel/effektHoleInfo.ts
+++ b/src/holesPanel/effektHoleInfo.ts
@@ -18,8 +18,8 @@ export interface TermBinding {
   qualifier: string[];
   name: string;
   origin: BindingOrigin;
-  type?: string;
-  typeHtml?: string;
+  signature?: string;
+  signatureHtml?: string;
   kind: typeof BINDING_KIND_TERM;
 }
 
@@ -27,8 +27,8 @@ export interface TypeBinding {
   qualifier: string[];
   name: string;
   origin: BindingOrigin;
-  definition: string;
-  definitionHtml?: string;
+  signature?: string;
+  signatureHtml?: string;
   kind: typeof BINDING_KIND_TYPE;
 }
 

--- a/src/holesPanel/webview/BindingItem.tsx
+++ b/src/holesPanel/webview/BindingItem.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  BINDING_KIND_TERM,
-  BindingInfo,
-  fullyQualifiedName,
-  TermBinding,
-  TypeBinding,
-} from '../effektHoleInfo';
+import { BindingInfo } from '../effektHoleInfo';
 
 interface BindingItemProps {
   binding: BindingInfo;
@@ -13,34 +7,11 @@ interface BindingItemProps {
 
 export const BindingItem: React.FC<BindingItemProps> = ({ binding }) => {
   return (
-    <div className="binding">
-      <>
-        {binding.kind === BINDING_KIND_TERM ? (
-          fullyQualifiedName(binding as TermBinding)
-        ) : (binding as TypeBinding).definitionHtml ? (
-          <span
-            dangerouslySetInnerHTML={{
-              __html: (binding as TypeBinding).definitionHtml!,
-            }}
-          />
-        ) : (
-          binding.definition || binding.name
-        )}
-      </>
-      {binding.kind === BINDING_KIND_TERM && (binding as TermBinding).type && (
-        <>
-          {': '}
-          {(binding as TermBinding).typeHtml ? (
-            <span
-              dangerouslySetInnerHTML={{
-                __html: (binding as TermBinding).typeHtml!,
-              }}
-            />
-          ) : (
-            (binding as TermBinding).type
-          )}
-        </>
-      )}
-    </div>
+    <div
+      className="binding"
+      dangerouslySetInnerHTML={{
+        __html: binding.signatureHtml!,
+      }}
+    ></div>
   );
 };

--- a/src/holesPanel/webview/BindingsSection.tsx
+++ b/src/holesPanel/webview/BindingsSection.tsx
@@ -54,7 +54,7 @@ export const BindingsSection: React.FC<BindingsSectionProps> = ({
 
   const miniSearch = useMemo(() => {
     const search = new MiniSearch({
-      fields: ['name', 'qualifier', 'signature'],
+      fields: ['signature'],
       storeFields: ['name', 'qualifier', 'origin', 'kind', 'signature'],
       idField: 'id',
     });
@@ -75,7 +75,7 @@ export const BindingsSection: React.FC<BindingsSectionProps> = ({
     }
 
     const searchResults = miniSearch.search(filter, {
-      combineWith: 'OR',
+      combineWith: 'AND',
       fuzzy: 0.2,
       prefix: true,
     });

--- a/src/holesPanel/webview/BindingsSection.tsx
+++ b/src/holesPanel/webview/BindingsSection.tsx
@@ -54,15 +54,8 @@ export const BindingsSection: React.FC<BindingsSectionProps> = ({
 
   const miniSearch = useMemo(() => {
     const search = new MiniSearch({
-      fields: ['name', 'qualifier', 'type', 'definition'],
-      storeFields: [
-        'name',
-        'qualifier',
-        'origin',
-        'kind',
-        'type',
-        'definition',
-      ],
+      fields: ['name', 'qualifier', 'signature'],
+      storeFields: ['name', 'qualifier', 'origin', 'kind', 'signature'],
       idField: 'id',
     });
 

--- a/src/holesPanel/webview/BindingsSection.tsx
+++ b/src/holesPanel/webview/BindingsSection.tsx
@@ -55,7 +55,6 @@ export const BindingsSection: React.FC<BindingsSectionProps> = ({
   const miniSearch = useMemo(() => {
     const search = new MiniSearch({
       fields: ['signature'],
-      storeFields: ['name', 'qualifier', 'origin', 'kind', 'signature'],
       idField: 'id',
     });
 


### PR DESCRIPTION
Display unified signature information rather than making a distinction between type and term bindings.