### PR TITLE
Fix highlighting of the "at" soft keyword

### DIFF
--- a/syntaxes/effekt.tmLanguage.json
+++ b/syntaxes/effekt.tmLanguage.json
@@ -145,7 +145,7 @@
       ]
     },
     "boxed_types": {
-      "comment": "Used for boxed types like 'at io' 'at {}', 'at {io}', 'at {io, global}', etc.",
+      "comment": "Used for boxed types like 'at io', 'at {}', 'at {io}', 'at {io, global}', etc.",
       "patterns": [
         {
           "begin": "\\b(at)\\s*\\{",


### PR DESCRIPTION
Before:

<img width="1690" height="481" alt="image" src="https://github.com/user-attachments/assets/60b13f5b-ac49-4bb7-8c3b-201a6af766d9" />

After:

<img width="1690" height="481" alt="image" src="https://github.com/user-attachments/assets/71a555db-9a82-4102-9ff4-742b880560fc" />
