### PR TITLE
Improve performance of hole bindings selection change

### DIFF
--- a/src/holesPanel/webview/BindingItem.tsx
+++ b/src/holesPanel/webview/BindingItem.tsx
@@ -8,40 +8,42 @@ interface BindingItemProps {
   onJumpToDefinition: (location: LSPLocation) => void;
 }
 
-export const BindingItem: React.FC<BindingItemProps> = ({
-  binding,
-  isSelected = false,
-  onJumpToDefinition,
-}) => {
-  const ref = useRef<HTMLDivElement>(null);
+// It is important that this component is memoized to avoid re-renders on selection changes
+export const BindingItem = React.memo<BindingItemProps>(
+  ({ binding, isSelected = false, onJumpToDefinition }) => {
+    const ref = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (isSelected && ref.current) {
-      ref.current.scrollIntoView({ behavior: 'instant', block: 'center' });
-    }
-  }, [isSelected]);
-
-  const handleClick = () => {
-    if (binding.definitionLocation) {
-      onJumpToDefinition(binding.definitionLocation);
-    }
-  };
-
-  const canJumpToDefinition = !!binding.definitionLocation;
-
-  return (
-    <div
-      ref={ref}
-      className={`binding ${canJumpToDefinition ? 'clickable' : ''} ${isSelected ? 'selected' : ''}`}
-      onClick={handleClick}
-      title={
-        canJumpToDefinition
-          ? `Jump to definition of ${binding.name}`
-          : undefined
+    useEffect(() => {
+      if (isSelected && ref.current) {
+        // Throttle to next frame to avoid layout thrash during rapid key repeats
+        requestAnimationFrame(() => {
+          ref.current?.scrollIntoView({ block: 'center' });
+        });
       }
-      dangerouslySetInnerHTML={{
-        __html: binding.signatureHtml!,
-      }}
-    ></div>
-  );
-};
+    }, [isSelected]);
+
+    const handleClick = () => {
+      if (binding.definitionLocation) {
+        onJumpToDefinition(binding.definitionLocation);
+      }
+    };
+
+    const canJumpToDefinition = !!binding.definitionLocation;
+
+    return (
+      <div
+        ref={ref}
+        className={`binding ${canJumpToDefinition ? 'clickable' : ''} ${isSelected ? 'selected' : ''}`}
+        onClick={handleClick}
+        title={
+          canJumpToDefinition
+            ? `Jump to definition of ${binding.name}`
+            : undefined
+        }
+        dangerouslySetInnerHTML={{
+          __html: binding.signatureHtml!,
+        }}
+      ></div>
+    );
+  },
+);


### PR DESCRIPTION
Previously, when pressing down the up/down arrow keys, rapidly changing the selected binding caused visible stutters. This PR fixes these performance issues using memoization to prevent unnecessary recomputation of the binding lists and unnecessary rerendering of the corresponding React components.
On my machine, this resolves any observable performance issues.