### PR TITLE
Add missing linebreak between expected and actual type

### DIFF
--- a/src/holesPanel/webview/holes.css
+++ b/src/holesPanel/webview/holes.css
@@ -75,7 +75,7 @@ pre {
 
 .hole-field {
   margin: 12px 0;
-  display: inline-block;
+  display: block;
   cursor: default;
 }
 


### PR DESCRIPTION
Before:

<img width="418" height="148" alt="image" src="https://github.com/user-attachments/assets/de4391b7-6c34-488e-8d25-3fb5c96f7695" />

After:

<img width="418" height="148" alt="image" src="https://github.com/user-attachments/assets/63768768-ab57-4f72-96d7-8862fb35cbc0" />
