### PR TITLE
Accurate InlayHints

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
           "default": true,
           "markdownDescription": "Show inlay hints for function return types:\n\n ```effekt\ndef foo()': Int / { raise }' = { do raise(); 5 } \n```"
         },
+        "effekt.inlayHints.accurate": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Remove inaccurate inlay hints after file changes"
+        },
         "effekt.showHoles": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
I added the ability to enable a more 'accurate' version of inlay hints, where all inlay changes are removed from the client until code is recompiled (currently until the file is saved). 

This setting defaults to `false` to preserve current behavior. 

This feature also includes changes to the `Server.scala` LSP
https://github.com/effekt-lang/effekt/compare/master...Plixo2:effekt:inlay-change-fix

Should i create a Issue or a PR for these changes in the main repo, or should we keep the discussion here?

