### PR TITLE
Add missing core keywords to ir syntax highlighting

### DIFF
--- a/syntaxes/ir.tmLanguage.json
+++ b/syntaxes/ir.tmLanguage.json
@@ -68,11 +68,11 @@
     "keywords": {
       "patterns": [
         {
-          "match": "\\b(module|import|export|def|fun|val|var|effect|type|match|case|record|extern|include|box|unbox|in|region|new|let|stack|get|put|interface)\\b",
+          "match": "\\b(module|import|export|def|fun|val|var|effect|type|match|case|record|extern|include|box|unbox|in|region|new|let|stack|get|put|interface|loadVar|storeVar|invoke|coerce)\\b",
           "name": "keyword.syntax"
         },
         {
-          "match": "\\b(resume|while|try|with|if|else|do|return|reset|shift|switch|push|jump|shift0)\\b",
+          "match": "\\b(resume|while|try|with|if|else|do|return|reset|shift|switch|jump)\\b",
           "name": "keyword.control"
         }
       ]


### PR DESCRIPTION
The IR syntax definition is shared between the different IRs. I added missing keywords for effekt's core IR that are printed by the updated pretty-printer.