### PR TITLE
Change default branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,10 @@ Then, in a separate instance of VSCode, test the extension on some Effekt code.
 
 This section describes how to release a new version of the Effekt VSCode extension to the VSCode Marketplace.
 
-Make sure you're on the latest `master` by running:
+Make sure you're on the latest `main` by running:
 
 ```sh
-git checkout master && git pull
+git checkout main && git pull
 ```
 
 Depending on whether the new change is minor or a patch (choose one), run:


### PR DESCRIPTION
Checklist:

* [x] Temporarily create `main` branch and check that CI runs through (ensure no release-related workflows run before doing so)
* [x] Use the GitHub rename branch feature to rename `master` to `main`
   This should make the following steps redundant (do verify before proceeding):
   * [x] Change default branch in GitHub settings to `main`
   * [x] Change target branch of all open PRs from `master` to `main` 
* [ ] Merge this PR into `main`
* [ ] Execute migration in the other repositories: [effekt](https://github.com/effekt-lang/effekt/pull/1261), [effekt-website](https://github.com/effekt-lang/effekt-website/pull/129) 

> [!note]
> I temporarily created a `main` branch to verify the CI runs through. I removed the branch again to prevent the release workflow from potentially running twice.
